### PR TITLE
Add canonical URLs to HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>404 — Page not found | Polished & Pristine</title>
   <meta name="description" content="Page not found — Polished & Pristine detailing in Darlington. Return home or use the menu to find what you need." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/404.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {

--- a/ceramic-coatings.html
+++ b/ceramic-coatings.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Ceramic Coatings — Polished & Pristine Darlington</title>
   <meta name="description" content="Ceramic coatings in Darlington— durable hydrophobic protection, UV defence, and long-lasting gloss." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/ceramic-coatings.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Contact & Book — Polished & Pristine</title>
   <meta name="description" content="Contact Polished & Pristine for paint correction, ceramic coatings, PPF and valeting services in Darlington." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/contact.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script> tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}</script>
 </head>

--- a/gallery.html
+++ b/gallery.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Gallery — Polished & Pristine | Before & After</title>
   <meta name="description" content="Before & after images and videos showcasing paint correction, ceramic coatings and PPF by Polished & Pristine in Darlington." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/gallery.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Paint Correction & Ceramic Coatings Darlington — Polished & Pristine</title>
   <meta name="description" content="Specialist paint correction, ceramic coatings and paint protection in Darlington. Restore gloss, remove defects and protect your vehicle with professional, long-lasting finishes." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/index.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {

--- a/paint-correction.html
+++ b/paint-correction.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Paint Correction — Polished & Pristine Darlington</title>
   <meta name="description" content="Paint correction services in Darlington — multi-stage polishing to remove swirls, oxidation and restore gloss." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/paint-correction.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}

--- a/ppf.html
+++ b/ppf.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Paint Protection Film (PPF) — Polished & Pristine</title>
   <meta name="description" content="Paint Protection Film in Darlington — invisible, self-healing film for bumpers, sills and high-impact areas." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/ppf.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}

--- a/services.html
+++ b/services.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Services — Polished & Pristine | Paint Enhancement & Protection</title>
   <meta name="description" content="Our services: paint correction, ceramic coatings, PPF, and valeting. Transparent pricing and professional workmanship in Darlington." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/services.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}

--- a/thank-you.html
+++ b/thank-you.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Thank you — Polished & Pristine</title>
+  <link rel="canonical" href="https://polishedandpristine.co.uk/thank-you.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script> tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}</script>
 </head>

--- a/tips.html
+++ b/tips.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Expert Advice — Polished & Pristine Darlington</title>
   <meta name="description" content="Expert car detailing tips and FAQ covering paint correction, ceramic coatings, PPF, valeting and more." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/tips.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}

--- a/valeting.html
+++ b/valeting.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Valeting & Interior Cleaning — Polished & Pristine</title>
   <meta name="description" content="Valeting and interior deep clean services in Darlington. Steam sanitisation, stain removal, and maintenance valets." />
+  <link rel="canonical" href="https://polishedandpristine.co.uk/valeting.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}


### PR DESCRIPTION
## Summary
- define canonical URLs for each HTML page to match the deployed polishedandpristine.co.uk structure

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9793ecfe08333b36b735fba3af0b6