### PR TITLE
refactor: centralize header and footer

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -26,53 +28,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- Shared header / nav -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-14 h-14 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
-      </nav>
-
-      <!-- Mobile toggle -->
-      <div class="md:hidden">
-        <button id="mobileMenuBtn404" class="p-2 rounded bg-slate-100" aria-label="Open menu">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
-          </svg>
-        </button>
-      </div>
-    </div>
-
-    <!-- Mobile menu -->
-    <div id="mobileMenu404" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block">Services</a>
-        <a href="/paint-correction.html" class="block">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block">PPF</a>
-        <a href="/valeting.html" class="block">Valeting</a>
-        <a href="/gallery.html" class="block">Gallery</a>
-        <a href="/tips.html" class="block">Expert Advice</a>
-        <a href="/contact.html" class="block font-semibold">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <!-- Main 404 content -->
   <main class="max-w-4xl mx-auto p-6 text-center">
@@ -94,17 +50,7 @@
   </main>
 
   <!-- Shared footer -->
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
-
-<script>
-  // Mobile menu toggle for 404
-  document.getElementById('mobileMenuBtn404').addEventListener('click', () => {
-    document.getElementById('mobileMenu404').classList.toggle('hidden');
-  });
-</script>
+  {% include partials/footer.html %}
 
 </body>
 </html>

--- a/_includes/partials/footer.html
+++ b/_includes/partials/footer.html
@@ -1,0 +1,12 @@
+<footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
+  Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
+  <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
+</footer>
+
+<script>
+  // Mobile menu toggle
+  document.getElementById('mobileMenuBtn').addEventListener('click', () => {
+    const m = document.getElementById('mobileMenu');
+    m.classList.toggle('hidden');
+  });
+</script>

--- a/_includes/partials/header.html
+++ b/_includes/partials/header.html
@@ -1,0 +1,43 @@
+<header class="bg-white shadow">
+  <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
+    <a href="/index.html" class="flex items-center gap-3">
+      <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-14 h-14 object-contain rounded" />
+      <div>
+        <div class="font-bold text-lg">Polished & Pristine</div>
+        <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
+      </div>
+    </a>
+    <nav class="hidden md:flex gap-6 text-sm items-center">
+      <a href="/index.html" class="hover:text-brandGold">Home</a>
+      <a href="/services.html" class="hover:text-brandGold">Services</a>
+      <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
+      <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
+      <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
+      <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
+      <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
+      <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
+      <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
+    </nav>
+    <!-- Mobile toggle -->
+    <div class="md:hidden">
+      <button id="mobileMenuBtn" class="p-2 rounded bg-slate-100">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- Mobile menu (hidden by default) -->
+  <div id="mobileMenu" class="hidden md:hidden border-t">
+    <div class="px-4 py-3 space-y-2">
+      <a href="/index.html" class="block">Home</a>
+      <a href="/services.html" class="block">Services</a>
+      <a href="/paint-correction.html" class="block">Paint Correction</a>
+      <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
+      <a href="/ppf.html" class="block">PPF</a>
+      <a href="/valeting.html" class="block">Valeting</a>
+      <a href="/gallery.html" class="block">Gallery</a>
+      <a href="/tips.html" class="block">Expert Advice</a>
+      <a href="/contact.html" class="block font-semibold">Contact / Book</a>
+    </div>
+  </div>
+</header>

--- a/ceramic-coatings.html
+++ b/ceramic-coatings.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -13,46 +15,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- header/nav (same as other pages) -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-12 h-12 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold font-semibold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
-      </nav>
-      <div class="md:hidden">
-        <button id="mobileMenuBtn4" class="p-2 rounded bg-slate-100">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
-        </button>
-      </div>
-    </div>
-    <div id="mobileMenu4" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block">Services</a>
-        <a href="/paint-correction.html" class="block">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block font-semibold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block">PPF</a>
-        <a href="/valeting.html" class="block">Valeting</a>
-        <a href="/gallery.html" class="block">Gallery</a>
-        <a href="/tips.html" class="block">Expert Advice</a>
-        <a href="/contact.html" class="block">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <main class="max-w-6xl mx-auto p-6">
     <h1 class="text-3xl font-extrabold mb-4">Ceramic Coatings — long-lasting protection</h1>
@@ -75,16 +38,7 @@
     </section>
   </main>
 
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
-
-<script>
-  document.getElementById('mobileMenuBtn4').addEventListener('click', () => {
-    document.getElementById('mobileMenu4').classList.toggle('hidden');
-  });
-</script>
+  {% include partials/footer.html %}
 
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -11,46 +13,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- header/nav -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-12 h-12 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded font-semibold">Contact / Book</a>
-      </nav>
-      <div class="md:hidden">
-        <button id="mobileMenuBtn9" class="p-2 rounded bg-slate-100">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
-        </button>
-      </div>
-    </div>
-    <div id="mobileMenu9" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block">Services</a>
-        <a href="/paint-correction.html" class="block">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block">PPF</a>
-        <a href="/valeting.html" class="block">Valeting</a>
-        <a href="/gallery.html" class="block">Gallery</a>
-        <a href="/tips.html" class="block">Expert Advice</a>
-        <a href="/contact.html" class="block font-semibold">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <main class="max-w-6xl mx-auto p-6">
     <h1 class="text-3xl font-extrabold mb-6 text-center">Get in Touch</h1>
@@ -89,16 +52,7 @@
     </div>
   </main>
 
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
-
-<script>
-  document.getElementById('mobileMenuBtn9').addEventListener('click', () => {
-    document.getElementById('mobileMenu9').classList.toggle('hidden');
-  });
-</script>
+  {% include partials/footer.html %}
 
 </body>
 </html>

--- a/gallery.html
+++ b/gallery.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -13,46 +15,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- header/nav -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-12 h-12 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold font-semibold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
-      </nav>
-      <div class="md:hidden">
-        <button id="mobileMenuBtn7" class="p-2 rounded bg-slate-100">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
-        </button>
-      </div>
-    </div>
-    <div id="mobileMenu7" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block">Services</a>
-        <a href="/paint-correction.html" class="block">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block">PPF</a>
-        <a href="/valeting.html" class="block">Valeting</a>
-        <a href="/gallery.html" class="block font-semibold">Gallery</a>
-        <a href="/tips.html" class="block">Expert Advice</a>
-        <a href="/contact.html" class="block">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <main class="max-w-6xl mx-auto p-6">
     <h1 class="text-3xl font-extrabold mb-6">Gallery — real results</h1>
@@ -81,16 +44,7 @@
 
   </main>
 
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
-
-<script>
-  document.getElementById('mobileMenuBtn7').addEventListener('click', () => {
-    document.getElementById('mobileMenu7').classList.toggle('hidden');
-  });
-</script>
+  {% include partials/footer.html %}
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -49,49 +51,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- Shared header / nav -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-14 h-14 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
-      </nav>
-      <!-- Mobile toggle -->
-      <div class="md:hidden">
-        <button id="mobileMenuBtn" class="p-2 rounded bg-slate-100">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
-        </button>
-      </div>
-    </div>
-
-    <!-- Mobile menu (hidden by default) -->
-    <div id="mobileMenu" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block">Services</a>
-        <a href="/paint-correction.html" class="block">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block">PPF</a>
-        <a href="/valeting.html" class="block">Valeting</a>
-        <a href="/gallery.html" class="block">Gallery</a>
-        <a href="/tips.html" class="block">Expert Advice</a>
-        <a href="/contact.html" class="block font-semibold">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <main class="max-w-6xl mx-auto p-6">
     <!-- Hero -->
@@ -175,18 +135,7 @@
   </main>
 
   <!-- Shared footer -->
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
-
-<script>
-  // Mobile menu toggle
-  document.getElementById('mobileMenuBtn').addEventListener('click', () => {
-    const m = document.getElementById('mobileMenu');
-    m.classList.toggle('hidden');
-  });
-</script>
+  {% include partials/footer.html %}
 
 </body>
 </html>

--- a/paint-correction.html
+++ b/paint-correction.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -13,46 +15,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- same header/nav -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-12 h-12 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold font-semibold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
-      </nav>
-      <div class="md:hidden">
-        <button id="mobileMenuBtn3" class="p-2 rounded bg-slate-100">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
-        </button>
-      </div>
-    </div>
-    <div id="mobileMenu3" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block">Services</a>
-        <a href="/paint-correction.html" class="block font-semibold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block">PPF</a>
-        <a href="/valeting.html" class="block">Valeting</a>
-        <a href="/gallery.html" class="block">Gallery</a>
-        <a href="/tips.html" class="block">Expert Advice</a>
-        <a href="/contact.html" class="block">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <main class="max-w-6xl mx-auto p-6">
     <h1 class="text-3xl font-extrabold mb-4">Paint Correction — restore clarity and gloss</h1>
@@ -76,16 +39,7 @@
     </section>
   </main>
 
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
-
-<script>
-  document.getElementById('mobileMenuBtn3').addEventListener('click', () => {
-    document.getElementById('mobileMenu3').classList.toggle('hidden');
-  });
-</script>
+  {% include partials/footer.html %}
 
 </body>
 </html>

--- a/ppf.html
+++ b/ppf.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -13,46 +15,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- header/nav -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-12 h-12 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold font-semibold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
-      </nav>
-      <div class="md:hidden">
-        <button id="mobileMenuBtn5" class="p-2 rounded bg-slate-100">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
-        </button>
-      </div>
-    </div>
-    <div id="mobileMenu5" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block">Services</a>
-        <a href="/paint-correction.html" class="block">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block font-semibold">PPF</a>
-        <a href="/valeting.html" class="block">Valeting</a>
-        <a href="/gallery.html" class="block">Gallery</a>
-        <a href="/tips.html" class="block">Expert Advice</a>
-        <a href="/contact.html" class="block">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <main class="max-w-6xl mx-auto p-6">
     <h1 class="text-3xl font-extrabold mb-4">Paint Protection Film (PPF)</h1>
@@ -70,16 +33,7 @@
     </section>
   </main>
 
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
-
-<script>
-  document.getElementById('mobileMenuBtn5').addEventListener('click', () => {
-    document.getElementById('mobileMenu5').classList.toggle('hidden');
-  });
-</script>
+  {% include partials/footer.html %}
 
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -13,46 +15,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- Shared header/nav (same as index) -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-12 h-12 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold font-semibold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
-      </nav>
-      <div class="md:hidden">
-        <button id="mobileMenuBtn2" class="p-2 rounded bg-slate-100">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
-        </button>
-      </div>
-    </div>
-    <div id="mobileMenu2" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block font-semibold">Services</a>
-        <a href="/paint-correction.html" class="block">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block">PPF</a>
-        <a href="/valeting.html" class="block">Valeting</a>
-        <a href="/gallery.html" class="block">Gallery</a>
-        <a href="/tips.html" class="block">Expert Advice</a>
-        <a href="/contact.html" class="block">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <main class="max-w-6xl mx-auto p-6">
     <h1 class="text-3xl font-extrabold mb-4">Services — Focused on Paint Enhancement</h1>
@@ -97,16 +60,7 @@
 
   </main>
 
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
-
-<script>
-  document.getElementById('mobileMenuBtn2').addEventListener('click', () => {
-    document.getElementById('mobileMenu2').classList.toggle('hidden');
-  });
-</script>
+  {% include partials/footer.html %}
 
 </body>
 </html>

--- a/thank-you.html
+++ b/thank-you.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -8,11 +10,12 @@
   <script> tailwind.config = { theme: { extend: { colors: { brandBlue: "#1e3a8a", brandGold: "#facc15", brandDark: "#0f172a" }}}}</script>
 </head>
 <body class="bg-slate-50 text-slate-900 antialiased">
+{% include partials/header.html %}
   <main class="max-w-4xl mx-auto p-6 text-center">
-    <img src="/images/logo.jpg" alt="Polished & Pristine" class="mx-auto w-24 h-24 mb-4 rounded">
     <h1 class="text-2xl font-bold mb-2">Thanks — we’ve received your enquiry</h1>
     <p class="text-slate-700 mb-4">We’ll be in touch on 07468 286651 within 24 hours to arrange your consultation. If it’s urgent, please call.</p>
     <a href="/index.html" class="inline-block bg-brandDark text-white px-4 py-2 rounded">Back to home</a>
   </main>
+{% include partials/footer.html %}
 </body>
 </html>

--- a/tips.html
+++ b/tips.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -13,46 +15,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- header/nav (same) -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-12 h-12 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold font-semibold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
-      </nav>
-      <div class="md:hidden">
-        <button id="mobileMenuBtn8" class="p-2 rounded bg-slate-100">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
-        </button>
-      </div>
-    </div>
-    <div id="mobileMenu8" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block">Services</a>
-        <a href="/paint-correction.html" class="block">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block">PPF</a>
-        <a href="/valeting.html" class="block">Valeting</a>
-        <a href="/gallery.html" class="block">Gallery</a>
-        <a href="/tips.html" class="block font-semibold">Expert Advice</a>
-        <a href="/contact.html" class="block">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <main class="max-w-6xl mx-auto p-6">
     <h1 class="text-3xl font-extrabold mb-4">Expert Detailing Tips & FAQ</h1>
@@ -81,18 +44,10 @@
     </div>
   </main>
 
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
+  {% include partials/footer.html %}
 
 <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2"></script>
 <script>
-  // Mobile menu toggle
-  document.getElementById('mobileMenuBtn8').addEventListener('click', () => {
-    document.getElementById('mobileMenu8').classList.toggle('hidden');
-  });
-
   // FAQ data (30 items) - same content we agreed earlier
   const faqData = [
     {q: "What’s the real difference between a car wash, a valet, and a detail?", a: "A basic car wash cleans surfaces. A valet uses safe methods for a thorough clean. Detailing restores, protects and perfects with decontamination and polish."},

--- a/valeting.html
+++ b/valeting.html
@@ -1,3 +1,5 @@
+---
+---
 <!doctype html>
 <html lang="en-GB">
 <head>
@@ -13,46 +15,7 @@
 <body class="bg-slate-50 text-slate-900 antialiased">
 
   <!-- header/nav -->
-  <header class="bg-white shadow">
-    <div class="max-w-6xl mx-auto p-4 flex items-center justify-between">
-      <a href="/index.html" class="flex items-center gap-3">
-        <img src="/images/logo.jpg" alt="Polished & Pristine logo" class="w-12 h-12 object-contain rounded" />
-        <div>
-          <div class="font-bold text-lg">Polished & Pristine</div>
-          <div class="text-sm text-slate-500">Paint correction • Ceramic coatings • PPF — Darlington</div>
-        </div>
-      </a>
-      <nav class="hidden md:flex gap-6 text-sm items-center">
-        <a href="/index.html" class="hover:text-brandGold">Home</a>
-        <a href="/services.html" class="hover:text-brandGold">Services</a>
-        <a href="/paint-correction.html" class="hover:text-brandGold">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="hover:text-brandGold">Ceramic Coatings</a>
-        <a href="/ppf.html" class="hover:text-brandGold">PPF</a>
-        <a href="/valeting.html" class="hover:text-brandGold font-semibold">Valeting</a>
-        <a href="/gallery.html" class="hover:text-brandGold">Gallery</a>
-        <a href="/tips.html" class="hover:text-brandGold">Expert Advice</a>
-        <a href="/contact.html" class="px-3 py-1 bg-brandDark text-white rounded">Contact / Book</a>
-      </nav>
-      <div class="md:hidden">
-        <button id="mobileMenuBtn6" class="p-2 rounded bg-slate-100">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
-        </button>
-      </div>
-    </div>
-    <div id="mobileMenu6" class="hidden md:hidden border-t">
-      <div class="px-4 py-3 space-y-2">
-        <a href="/index.html" class="block">Home</a>
-        <a href="/services.html" class="block">Services</a>
-        <a href="/paint-correction.html" class="block">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="block">Ceramic Coatings</a>
-        <a href="/ppf.html" class="block">PPF</a>
-        <a href="/valeting.html" class="block font-semibold">Valeting</a>
-        <a href="/gallery.html" class="block">Gallery</a>
-        <a href="/tips.html" class="block">Expert Advice</a>
-        <a href="/contact.html" class="block">Contact / Book</a>
-      </div>
-    </div>
-  </header>
+  {% include partials/header.html %}
 
   <main class="max-w-6xl mx-auto p-6">
     <h1 class="text-3xl font-extrabold mb-4">Valeting & Interior Cleaning</h1>
@@ -70,16 +33,7 @@
     </section>
   </main>
 
-  <footer class="mt-12 border-t py-6 text-sm text-center text-slate-600">
-    Polished & Pristine — 3 Appleby Close, Darlington — DL1 4AJ — <a href="tel:07468286651" class="text-slate-900">07468 286651</a>
-    <div class="mt-2">Serving approx. 25-mile radius | Proudly local</div>
-  </footer>
-
-<script>
-  document.getElementById('mobileMenuBtn6').addEventListener('click', () => {
-    document.getElementById('mobileMenu6').classList.toggle('hidden');
-  });
-</script>
+  {% include partials/footer.html %}
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract shared header and footer into `_includes/partials/`
- replace repeated markup on each page with Jekyll includes
- add front matter to HTML pages to enable include processing

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b979258c4c8333929f260409bc8300