### PR TITLE
Add dynamic vehicle selectors to contact booking form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -60,12 +60,18 @@
         <h2>Send a booking request</h2>
 
         <form action="https://formsubmit.co/b89300d152399ad939e7db161cbb0cfa"
-              method="POST" enctype="multipart/form-data" style="margin-top:10px;">
+              method="POST" enctype="multipart/form-data" style="margin-top:10px;"
+              data-booking-form>
           <!-- FormSubmit controls -->
           <input type="hidden" name="_next" value="https://polishedandpristine.co.uk/thank-you.html">
           <input type="hidden" name="_subject" value="Website enquiry: Polished &amp; Pristine">
           <input type="hidden" name="_template" value="table">
           <input type="hidden" name="_captcha" value="false">
+          <input type="hidden" name="vehicle_make" id="vehicleMakeHidden">
+          <input type="hidden" name="vehicle_model" id="vehicleModelHidden">
+          <input type="hidden" name="vehicle_variant" id="vehicleVariantHidden">
+          <input type="hidden" name="vehicle_category" id="vehicleCategoryHidden">
+          <input type="hidden" name="vehicle_condition" id="vehicleConditionHidden">
           <!-- Honeypot (spam trap) -->
           <input type="text" name="_honey" style="display:none">
 
@@ -94,6 +100,47 @@
               <label for="reg">Vehicle reg</label>
               <input id="reg" name="reg"
                      style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+            </div>
+            <div style="grid-column:1/-1;">
+              <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:12px;">
+                <div>
+                  <label for="vehicleMake">Vehicle make</label>
+                  <select id="vehicleMake" required
+                          style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                    <option value="">Select make</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="vehicleModel">Model</label>
+                  <select id="vehicleModel" required disabled
+                          style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                    <option value="">Select model</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="vehicleVariant">Year / variant</label>
+                  <select id="vehicleVariant" required disabled
+                          style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                    <option value="">Select year / variant</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="vehicleCategoryDisplay">Size category</label>
+                  <input id="vehicleCategoryDisplay" type="text" readonly placeholder="Select year / variant" data-category=""
+                         style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#111b2f; color:#e5e7eb; margin-top:6px;">
+                </div>
+                <div>
+                  <label for="vehicleCondition">Vehicle condition</label>
+                  <select id="vehicleCondition" required
+                          style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                    <option value="">Select condition</option>
+                    <option value="Excellent">Excellent (new / ceramic-ready)</option>
+                    <option value="Good">Good (light marring)</option>
+                    <option value="Needs correction">Needs correction (swirls, scratches)</option>
+                    <option value="Severe correction">Severe correction (oxidation / heavy defects)</option>
+                  </select>
+                </div>
+              </div>
             </div>
             <div>
               <label for="service">Service</label>
@@ -191,6 +238,8 @@
   </footer>
 
   <!-- Mobile nav toggle -->
+  <script src="/complete_vehicle_database.js"></script>
+  <script src="/js/booking.js"></script>
   <script>
     (function(){
       const btn = document.getElementById('mobileNavToggle');

--- a/js/booking.js
+++ b/js/booking.js
@@ -1,0 +1,146 @@
+(function () {
+  const form = document.querySelector('[data-booking-form]');
+  if (!form || typeof vehicleDatabase === 'undefined') {
+    return;
+  }
+
+  const makeSelect = form.querySelector('#vehicleMake');
+  const modelSelect = form.querySelector('#vehicleModel');
+  const variantSelect = form.querySelector('#vehicleVariant');
+  const conditionSelect = form.querySelector('#vehicleCondition');
+  const categoryDisplay = form.querySelector('#vehicleCategoryDisplay');
+
+  const hiddenMake = form.querySelector('#vehicleMakeHidden');
+  const hiddenModel = form.querySelector('#vehicleModelHidden');
+  const hiddenVariant = form.querySelector('#vehicleVariantHidden');
+  const hiddenCategory = form.querySelector('#vehicleCategoryHidden');
+  const hiddenCondition = form.querySelector('#vehicleConditionHidden');
+
+  if (
+    !makeSelect ||
+    !modelSelect ||
+    !variantSelect ||
+    !conditionSelect ||
+    !categoryDisplay ||
+    !hiddenMake ||
+    !hiddenModel ||
+    !hiddenVariant ||
+    !hiddenCategory ||
+    !hiddenCondition
+  ) {
+    return;
+  }
+
+  const createOption = (value, text) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = text;
+    return option;
+  };
+
+  const resetSelect = (select, placeholder) => {
+    select.innerHTML = '';
+    select.appendChild(createOption('', placeholder));
+    select.value = '';
+    select.disabled = true;
+  };
+
+  const populateMakes = () => {
+    resetSelect(makeSelect, 'Select make');
+    Object.keys(vehicleDatabase)
+      .sort((a, b) => a.localeCompare(b))
+      .forEach((make) => {
+        makeSelect.appendChild(createOption(make, make));
+      });
+    makeSelect.disabled = false;
+  };
+
+  const populateModels = (make) => {
+    resetSelect(modelSelect, 'Select model');
+    resetSelect(variantSelect, 'Select year / variant');
+    if (!make || !vehicleDatabase[make]) {
+      return;
+    }
+
+    Object.keys(vehicleDatabase[make])
+      .sort((a, b) => a.localeCompare(b))
+      .forEach((model) => {
+        modelSelect.appendChild(createOption(model, model));
+      });
+
+    modelSelect.disabled = false;
+  };
+
+  const populateVariants = (make, model) => {
+    resetSelect(variantSelect, 'Select year / variant');
+    if (!make || !model || !vehicleDatabase[make] || !vehicleDatabase[make][model]) {
+      return;
+    }
+
+    Object.keys(vehicleDatabase[make][model])
+      .sort((a, b) => a.localeCompare(b))
+      .forEach((variant) => {
+        variantSelect.appendChild(createOption(variant, variant));
+      });
+
+    variantSelect.disabled = false;
+  };
+
+  const updateHiddenFields = () => {
+    hiddenMake.value = makeSelect.value;
+    hiddenModel.value = modelSelect.value;
+    hiddenVariant.value = variantSelect.value;
+    hiddenCondition.value = conditionSelect.value;
+  };
+
+  const clearCategory = () => {
+    categoryDisplay.value = '';
+    categoryDisplay.dataset.category = '';
+    hiddenCategory.value = '';
+  };
+
+  populateMakes();
+  clearCategory();
+
+  makeSelect.addEventListener('change', () => {
+    updateHiddenFields();
+    clearCategory();
+    populateModels(makeSelect.value);
+  });
+
+  modelSelect.addEventListener('change', () => {
+    updateHiddenFields();
+    clearCategory();
+    populateVariants(makeSelect.value, modelSelect.value);
+  });
+
+  variantSelect.addEventListener('change', () => {
+    updateHiddenFields();
+    const make = makeSelect.value;
+    const model = modelSelect.value;
+    const variant = variantSelect.value;
+    if (make && model && variant && vehicleDatabase[make] && vehicleDatabase[make][model]) {
+      const details = vehicleDatabase[make][model][variant];
+      if (details && details.category) {
+        categoryDisplay.value = details.category;
+        categoryDisplay.dataset.category = details.category;
+        hiddenCategory.value = details.category;
+      } else {
+        clearCategory();
+      }
+    } else {
+      clearCategory();
+    }
+  });
+
+  conditionSelect.addEventListener('change', () => {
+    updateHiddenFields();
+  });
+
+  form.addEventListener('submit', () => {
+    updateHiddenFields();
+    if (!hiddenCategory.value && categoryDisplay.dataset.category) {
+      hiddenCategory.value = categoryDisplay.dataset.category;
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add cascading make/model/variant selectors with size category display to the contact form
- capture selected vehicle details and condition via hidden inputs for FormSubmit processing
- load a new booking helper script alongside the existing vehicle database and update the layout styling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d7dc21e2788333aa5ec00b9e2dc2b0