### PR TITLE
Allow package selection without vehicle database

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -66,8 +66,8 @@
       <article class="card">
         <h2>📊 Smart pricing engine</h2>
         <p class="muted">
-          Pricing automatically adjusts to the true vehicle size and chosen package (valet, correction or coatings).
-          You can still add extras such as clay bar treatment, engine bay detail or ceramic upgrades at checkout.
+          Pricing automatically adjusts to the true vehicle size, your chosen package (valet, correction or coatings) and the vehicle’s condition.
+          Extras such as clay bar treatment, engine bay detail or ceramic upgrades are added transparently to the running total.
         </p>
         <div class="muted" style="margin-top:12px;">
           <strong>Guideline size-based ranges</strong>
@@ -110,6 +110,9 @@
           <input type="hidden" name="vehicle_variant" id="vehicleVariantHidden">
           <input type="hidden" name="vehicle_category" id="vehicleCategoryHidden">
           <input type="hidden" name="vehicle_condition" id="vehicleConditionHidden">
+          <input type="hidden" name="service_package" id="servicePackageHidden">
+          <input type="hidden" name="selected_extras" id="selectedExtrasHidden">
+          <input type="hidden" name="calculated_total" id="calculatedTotalHidden">
           <!-- Honeypot (spam trap) -->
           <input type="text" name="_honey" style="display:none">
 
@@ -180,6 +183,31 @@
                 </div>
               </div>
             </div>
+            <div style="grid-column:1/-1; margin-top:4px; display:grid; gap:12px;">
+              <div>
+                <label for="servicePackage">Choose a package</label>
+                <select id="servicePackage" required
+                        style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                  <option value="">Select package (auto-pricing)</option>
+                </select>
+                <p class="muted" style="margin:6px 0 0; font-size:0.9rem;">Base prices adjust automatically to your detected vehicle size. Choose the package closest to what you need and we’ll confirm availability.</p>
+              </div>
+              <fieldset style="border:1px solid #2a3346; border-radius:10px; padding:12px;">
+                <legend style="padding:0 6px; font-size:0.95rem;">Optional add-ons</legend>
+                <p class="muted" style="margin:0 0 8px; font-size:0.9rem;">Tick extras for protection or deep-clean elements. Prices below already include the size-based adjustment.</p>
+                <div data-addon-list style="display:grid; gap:8px;"></div>
+              </fieldset>
+              <div style="background:#111b2f; border:1px solid #2a3346; border-radius:10px; padding:12px; display:flex; flex-direction:column; gap:6px;">
+                <strong>Total estimate</strong>
+                <div data-total-display style="font-size:1.4rem; font-weight:600;">Select vehicle &amp; package</div>
+                <ul data-total-breakdown style="list-style:none; padding:0; margin:0; display:grid; gap:2px; font-size:0.9rem;">
+                  <li data-total-base class="muted">Base package: —</li>
+                  <li data-total-condition class="muted">Condition uplift: —</li>
+                  <li data-total-extras class="muted">Extras: —</li>
+                </ul>
+                <p class="muted" style="margin:0; font-size:0.9rem;" data-total-note>Totals reflect the package price, condition uplift and any extras. Final invoice is confirmed after inspection.</p>
+              </div>
+            </div>
             <div>
               <label for="service">Service</label>
               <select id="service" name="service" required
@@ -218,7 +246,7 @@
             <a class="btn btn-outline" href="tel:07468286651">Call instead</a>
           </div>
 
-          <p class="muted" style="margin-top:10px;">Prefer WhatsApp? Message us on <a href="tel:07468286651">07468 286651</a> and include your reg &amp; postcode.</p>
+          <p class="muted" style="margin-top:10px;">Prefer WhatsApp? Message us on <a href="tel:07468286651">07468 286651</a> and include your reg &amp; postcode. We’ll confirm the package, condition uplift and extras before booking you in.</p>
         </form>
       </article>
 

--- a/contact.html
+++ b/contact.html
@@ -189,6 +189,11 @@
                 <select id="servicePackage" required
                         style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
                   <option value="">Select package (auto-pricing)</option>
+                  <option value="maintenance-valet" data-service="Valeting / Interior">Maintenance valet (exterior &amp; interior)</option>
+                  <option value="deep-clean-valet" data-service="Valeting / Interior">Deep clean valet + gloss boost</option>
+                  <option value="single-stage-correction" data-service="Paint correction">Single-stage paint correction</option>
+                  <option value="two-stage-ceramic" data-service="Ceramic coating (polish included)">Two-stage correction + 2yr ceramic</option>
+                  <option value="ppf-front" data-service="PPF">PPF partial front (bumper, bonnet, wings, mirrors)</option>
                 </select>
                 <p class="muted" style="margin:6px 0 0; font-size:0.9rem;">Base prices adjust automatically to your detected vehicle size. Choose the package closest to what you need and we’ll confirm availability.</p>
               </div>

--- a/js/booking.js
+++ b/js/booking.js
@@ -1,13 +1,25 @@
 (function () {
   const form = document.querySelector('[data-booking-form]');
-  if (!form || typeof vehicleDatabase === 'undefined') {
+  if (!form) {
     return;
   }
+
+  const hasVehicleDatabase = typeof vehicleDatabase !== 'undefined';
+  const database = hasVehicleDatabase ? vehicleDatabase : null;
 
   const makeSelect = form.querySelector('#vehicleMake');
   const modelSelect = form.querySelector('#vehicleModel');
   const variantSelect = form.querySelector('#vehicleVariant');
   const conditionSelect = form.querySelector('#vehicleCondition');
+  const packageSelect = form.querySelector('#servicePackage');
+  const serviceSelect = form.querySelector('#service');
+  const addonList = form.querySelector('[data-addon-list]');
+  const totalDisplay = form.querySelector('[data-total-display]');
+  const totalNote = form.querySelector('[data-total-note]');
+  const totalBase = form.querySelector('[data-total-base]');
+  const totalCondition = form.querySelector('[data-total-condition]');
+  const totalExtras = form.querySelector('[data-total-extras]');
+  let defaultTotalNote = totalNote ? totalNote.textContent : '';
   const categoryDisplay = form.querySelector('#vehicleCategoryDisplay');
 
   const hiddenMake = form.querySelector('#vehicleMakeHidden');
@@ -15,18 +27,31 @@
   const hiddenVariant = form.querySelector('#vehicleVariantHidden');
   const hiddenCategory = form.querySelector('#vehicleCategoryHidden');
   const hiddenCondition = form.querySelector('#vehicleConditionHidden');
+  const hiddenPackage = form.querySelector('#servicePackageHidden');
+  const hiddenExtras = form.querySelector('#selectedExtrasHidden');
+  const hiddenTotal = form.querySelector('#calculatedTotalHidden');
 
   if (
     !makeSelect ||
     !modelSelect ||
     !variantSelect ||
     !conditionSelect ||
+    !packageSelect ||
+    !serviceSelect ||
+    !addonList ||
+    !totalDisplay ||
+    !totalBase ||
+    !totalCondition ||
+    !totalExtras ||
     !categoryDisplay ||
     !hiddenMake ||
     !hiddenModel ||
     !hiddenVariant ||
     !hiddenCategory ||
-    !hiddenCondition
+    !hiddenCondition ||
+    !hiddenPackage ||
+    !hiddenExtras ||
+    !hiddenTotal
   ) {
     return;
   }
@@ -38,6 +63,163 @@
     return option;
   };
 
+  const pricingConfig = {
+    packages: [
+      {
+        id: 'maintenance-valet',
+        label: 'Maintenance valet (exterior & interior)',
+        service: 'Valeting / Interior',
+        description: '2-3 hour maintenance detail ideal for well-kept cars.',
+        pricing: {
+          'Small Car': 55,
+          'Medium Car': 65,
+          'Large Car': 75,
+          'Small SUV': 80,
+          SUV: 85,
+          Van: 110,
+          default: 70,
+        },
+      },
+      {
+        id: 'deep-clean-valet',
+        label: 'Deep clean valet + gloss boost',
+        service: 'Valeting / Interior',
+        description: 'Full interior shampoo, steam clean and machine glaze.',
+        pricing: {
+          'Small Car': 95,
+          'Medium Car': 110,
+          'Large Car': 125,
+          'Small SUV': 130,
+          SUV: 145,
+          Van: 170,
+          default: 120,
+        },
+      },
+      {
+        id: 'single-stage-correction',
+        label: 'Single-stage paint correction',
+        service: 'Paint correction',
+        description: 'Enhancement polish to remove light swirls and restore gloss.',
+        pricing: {
+          'Small Car': 220,
+          'Medium Car': 260,
+          'Large Car': 300,
+          'Small SUV': 310,
+          SUV: 340,
+          Van: 380,
+          default: 280,
+        },
+      },
+      {
+        id: 'two-stage-ceramic',
+        label: 'Two-stage correction + 2yr ceramic',
+        service: 'Ceramic coating (polish included)',
+        description: 'Heavy correction, panel wipe and 2-year ceramic coating.',
+        pricing: {
+          'Small Car': 420,
+          'Medium Car': 470,
+          'Large Car': 520,
+          'Small SUV': 540,
+          SUV: 580,
+          Van: 650,
+          default: 480,
+        },
+      },
+      {
+        id: 'ppf-front',
+        label: 'PPF partial front (bumper, bonnet, wings, mirrors)',
+        service: 'PPF',
+        description: 'Stone-chip protection film for the most exposed panels.',
+        pricing: {
+          'Small Car': 650,
+          'Medium Car': 700,
+          'Large Car': 780,
+          'Small SUV': 780,
+          SUV: 840,
+          Van: 900,
+          default: 720,
+        },
+      },
+    ],
+    conditionMultipliers: {
+      Excellent: 1,
+      Good: 1.08,
+      'Needs correction': 1.18,
+      'Severe correction': 1.35,
+      default: 1,
+    },
+    extras: [
+      {
+        id: 'glass-coating',
+        label: 'Glass coating (windscreen & fronts)',
+        pricing: {
+          'Small Car': 45,
+          'Medium Car': 45,
+          'Large Car': 50,
+          'Small SUV': 50,
+          SUV: 55,
+          Van: 55,
+          default: 45,
+        },
+      },
+      {
+        id: 'wheel-coating',
+        label: 'Wheel face ceramic upgrade',
+        pricing: {
+          default: 60,
+        },
+      },
+      {
+        id: 'interior-protectant',
+        label: 'Fabric & leather protection',
+        pricing: {
+          'Small Car': 60,
+          'Medium Car': 65,
+          'Large Car': 70,
+          'Small SUV': 70,
+          SUV: 75,
+          Van: 80,
+          default: 65,
+        },
+      },
+      {
+        id: 'engine-bay',
+        label: 'Engine bay detail',
+        pricing: {
+          Van: 45,
+          default: 35,
+        },
+      },
+      {
+        id: 'clay-bar',
+        label: 'Clay bar & tar removal',
+        pricing: {
+          'Small Car': 40,
+          'Medium Car': 45,
+          'Large Car': 50,
+          'Small SUV': 50,
+          SUV: 55,
+          Van: 60,
+          default: 45,
+        },
+      },
+    ],
+  };
+
+  const resolvePrice = (pricingMap, category) => {
+    if (!pricingMap) {
+      return 0;
+    }
+    if (category && Object.prototype.hasOwnProperty.call(pricingMap, category)) {
+      return pricingMap[category];
+    }
+    if (Object.prototype.hasOwnProperty.call(pricingMap, 'default')) {
+      return pricingMap.default;
+    }
+    const firstKey = Object.keys(pricingMap)[0];
+    return firstKey ? pricingMap[firstKey] : 0;
+  };
+
   const resetSelect = (select, placeholder) => {
     select.innerHTML = '';
     select.appendChild(createOption('', placeholder));
@@ -46,8 +228,24 @@
   };
 
   const populateMakes = () => {
-    resetSelect(makeSelect, 'Select make');
-    Object.keys(vehicleDatabase)
+    resetSelect(
+      makeSelect,
+      hasVehicleDatabase ? 'Select make' : 'Vehicle lookup unavailable'
+    );
+
+    if (!hasVehicleDatabase || !database) {
+      modelSelect.disabled = true;
+      variantSelect.disabled = true;
+      categoryDisplay.placeholder = 'Add vehicle details in the notes';
+      if (totalNote) {
+        totalNote.textContent =
+          'Vehicle lookup is temporarily unavailable. Use the notes box to tell us the make, model and year — we will confirm pricing manually.';
+        defaultTotalNote = totalNote.textContent;
+      }
+      return;
+    }
+
+    Object.keys(database)
       .sort((a, b) => a.localeCompare(b))
       .forEach((make) => {
         makeSelect.appendChild(createOption(make, make));
@@ -58,11 +256,11 @@
   const populateModels = (make) => {
     resetSelect(modelSelect, 'Select model');
     resetSelect(variantSelect, 'Select year / variant');
-    if (!make || !vehicleDatabase[make]) {
+    if (!hasVehicleDatabase || !database || !make || !database[make]) {
       return;
     }
 
-    Object.keys(vehicleDatabase[make])
+    Object.keys(database[make])
       .sort((a, b) => a.localeCompare(b))
       .forEach((model) => {
         modelSelect.appendChild(createOption(model, model));
@@ -73,11 +271,18 @@
 
   const populateVariants = (make, model) => {
     resetSelect(variantSelect, 'Select year / variant');
-    if (!make || !model || !vehicleDatabase[make] || !vehicleDatabase[make][model]) {
+    if (
+      !hasVehicleDatabase ||
+      !database ||
+      !make ||
+      !model ||
+      !database[make] ||
+      !database[make][model]
+    ) {
       return;
     }
 
-    Object.keys(vehicleDatabase[make][model])
+    Object.keys(database[make][model])
       .sort((a, b) => a.localeCompare(b))
       .forEach((variant) => {
         variantSelect.appendChild(createOption(variant, variant));
@@ -91,15 +296,211 @@
     hiddenModel.value = modelSelect.value;
     hiddenVariant.value = variantSelect.value;
     hiddenCondition.value = conditionSelect.value;
+    hiddenPackage.value = packageSelect.value;
+  };
+
+  const getCategory = () => categoryDisplay.dataset.category || categoryDisplay.value || '';
+
+  const getConditionMultiplier = () => {
+    const multiplier = pricingConfig.conditionMultipliers[conditionSelect.value];
+    return typeof multiplier === 'number'
+      ? multiplier
+      : pricingConfig.conditionMultipliers.default;
+  };
+
+  const getSelectedPackage = () =>
+    pricingConfig.packages.find((pkg) => pkg.id === packageSelect.value) || null;
+
+  const formatCurrency = (value) => {
+    if (!Number.isFinite(value)) {
+      return '—';
+    }
+    return `£${value.toFixed(0)}`;
+  };
+
+  const populatePackages = () => {
+    packageSelect.innerHTML = '';
+    packageSelect.appendChild(createOption('', 'Select package (auto-pricing)'));
+    pricingConfig.packages.forEach((pkg) => {
+      const option = createOption(pkg.id, pkg.label);
+      option.dataset.service = pkg.service;
+      if (pkg.description) {
+        option.title = pkg.description;
+      }
+      packageSelect.appendChild(option);
+    });
+    packageSelect.disabled = false;
+  };
+
+  const renderExtras = () => {
+    addonList.innerHTML = '';
+    pricingConfig.extras.forEach((extra) => {
+      const id = `addon-${extra.id}`;
+      const wrapper = document.createElement('label');
+      wrapper.setAttribute('for', id);
+      wrapper.style.display = 'grid';
+      wrapper.style.gridTemplateColumns = 'auto 1fr';
+      wrapper.style.alignItems = 'start';
+      wrapper.style.gap = '10px';
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.id = id;
+      checkbox.dataset.extraId = extra.id;
+      checkbox.dataset.extraLabel = extra.label;
+      checkbox.style.marginTop = '3px';
+
+      const textWrap = document.createElement('div');
+      const title = document.createElement('div');
+      title.textContent = extra.label;
+      title.style.fontWeight = '600';
+      const price = document.createElement('div');
+      price.className = 'muted';
+      price.style.fontSize = '0.9rem';
+      price.dataset.priceDisplay = extra.id;
+
+      textWrap.appendChild(title);
+      textWrap.appendChild(price);
+
+      wrapper.appendChild(checkbox);
+      wrapper.appendChild(textWrap);
+      addonList.appendChild(wrapper);
+    });
+  };
+
+  const getExtrasCheckboxes = () => addonList.querySelectorAll('input[type="checkbox"]');
+
+  const updateServiceSelection = (pkg) => {
+    if (!pkg) {
+      return;
+    }
+    const match = Array.from(serviceSelect.options).find(
+      (option) => option.value === pkg.service
+    );
+    if (match) {
+      serviceSelect.value = match.value;
+    }
+  };
+
+  const updateExtrasPricingDisplay = () => {
+    const category = getCategory();
+    pricingConfig.extras.forEach((extra) => {
+      const priceElement = addonList.querySelector(
+        `[data-price-display="${extra.id}"]`
+      );
+      if (!priceElement) {
+        return;
+      }
+      const price = resolvePrice(extra.pricing, category);
+      priceElement.textContent = price
+        ? `${formatCurrency(price)} inc. VAT`
+        : 'Included';
+    });
+  };
+
+  const updateTotal = () => {
+    const category = getCategory();
+    const selectedPackage = getSelectedPackage();
+    const packageBase = selectedPackage
+      ? resolvePrice(selectedPackage.pricing, category)
+      : 0;
+    const conditionMultiplier = getConditionMultiplier();
+
+    const extrasTotal = Array.from(getExtrasCheckboxes()).reduce((sum, checkbox) => {
+      if (!checkbox.checked) {
+        return sum;
+      }
+      const extra = pricingConfig.extras.find((item) => item.id === checkbox.dataset.extraId);
+      if (!extra) {
+        return sum;
+      }
+      return sum + resolvePrice(extra.pricing, category);
+    }, 0);
+
+    if (!selectedPackage) {
+      totalDisplay.textContent = category
+        ? 'Select a package to see pricing'
+        : 'Select vehicle & package';
+      hiddenTotal.value = '';
+      hiddenPackage.value = '';
+      hiddenExtras.value = '';
+      totalBase.textContent = 'Base package: —';
+      totalCondition.textContent = 'Condition uplift: —';
+      totalExtras.textContent = 'Extras: —';
+      if (totalNote) {
+        totalNote.textContent = defaultTotalNote;
+      }
+      return;
+    }
+
+    const adjustedBase = Math.round(packageBase * conditionMultiplier);
+    const total = adjustedBase + extrasTotal;
+    totalDisplay.textContent = formatCurrency(total);
+
+    if (totalBase) {
+      totalBase.textContent = `Base package: ${formatCurrency(packageBase)} (${selectedPackage.service})`;
+    }
+
+    if (totalCondition) {
+      if (!conditionSelect.value) {
+        totalCondition.textContent = 'Condition uplift: Waiting for condition';
+      } else if (conditionMultiplier > 1) {
+        const upliftValue = Math.max(0, adjustedBase - packageBase);
+        totalCondition.textContent = `Condition uplift: +${formatCurrency(upliftValue)} (${conditionSelect.value})`;
+      } else {
+        totalCondition.textContent = `Condition uplift: £0 (${conditionSelect.value})`;
+      }
+    }
+
+    const multiplierLabel = conditionSelect.value
+      ? `${conditionSelect.value} condition`
+      : 'Condition not provided';
+
+    const extrasSummary = Array.from(getExtrasCheckboxes())
+      .filter((checkbox) => checkbox.checked)
+      .map((checkbox) => {
+        const extra = pricingConfig.extras.find((item) => item.id === checkbox.dataset.extraId);
+        if (!extra) {
+          return checkbox.dataset.extraLabel;
+        }
+        const price = resolvePrice(extra.pricing, category);
+        return `${extra.label} (${formatCurrency(price)})`;
+      });
+
+    if (totalExtras) {
+      totalExtras.textContent =
+        extrasTotal > 0
+          ? `Extras: +${formatCurrency(extrasTotal)}`
+          : 'Extras: None selected';
+    }
+
+    hiddenPackage.value = `${selectedPackage.label} — base ${formatCurrency(
+      packageBase
+    )} (${multiplierLabel})`;
+    hiddenExtras.value = extrasSummary.length > 0 ? extrasSummary.join('; ') : 'None selected';
+    hiddenTotal.value = formatCurrency(total);
+
+    if (totalNote) {
+      totalNote.textContent = conditionSelect.value
+        ? 'Estimate = package price × condition uplift + extras. We confirm the figure after hands-on inspection.'
+        : 'Select a vehicle condition to confirm the uplift. Estimate currently assumes excellent condition.';
+    }
   };
 
   const clearCategory = () => {
     categoryDisplay.value = '';
     categoryDisplay.dataset.category = '';
     hiddenCategory.value = '';
+    categoryDisplay.placeholder = hasVehicleDatabase
+      ? 'Select year / variant'
+      : 'Add vehicle details in the notes';
+    updateExtrasPricingDisplay();
+    updateTotal();
   };
 
   populateMakes();
+  populatePackages();
+  renderExtras();
   clearCategory();
 
   makeSelect.addEventListener('change', () => {
@@ -116,18 +517,26 @@
 
   variantSelect.addEventListener('change', () => {
     updateHiddenFields();
+
+    if (!hasVehicleDatabase || !database) {
+      clearCategory();
+      return;
+    }
+
     const make = makeSelect.value;
     const model = modelSelect.value;
     const variant = variantSelect.value;
-    if (make && model && variant && vehicleDatabase[make] && vehicleDatabase[make][model]) {
-      const details = vehicleDatabase[make][model][variant];
-      if (details && details.category) {
-        categoryDisplay.value = details.category;
-        categoryDisplay.dataset.category = details.category;
-        hiddenCategory.value = details.category;
-      } else {
-        clearCategory();
-      }
+    const details =
+      make && model && variant && database[make] && database[make][model]
+        ? database[make][model][variant]
+        : null;
+
+    if (details && details.category) {
+      categoryDisplay.value = details.category;
+      categoryDisplay.dataset.category = details.category;
+      hiddenCategory.value = details.category;
+      updateExtrasPricingDisplay();
+      updateTotal();
     } else {
       clearCategory();
     }
@@ -135,6 +544,20 @@
 
   conditionSelect.addEventListener('change', () => {
     updateHiddenFields();
+    updateTotal();
+  });
+
+  packageSelect.addEventListener('change', () => {
+    updateHiddenFields();
+    const pkg = getSelectedPackage();
+    updateServiceSelection(pkg);
+    updateTotal();
+  });
+
+  addonList.addEventListener('change', (event) => {
+    if (event.target && event.target.matches('input[type="checkbox"]')) {
+      updateTotal();
+    }
   });
 
   form.addEventListener('submit', () => {
@@ -142,5 +565,6 @@
     if (!hiddenCategory.value && categoryDisplay.dataset.category) {
       hiddenCategory.value = categoryDisplay.dataset.category;
     }
+    updateTotal();
   });
 })();

--- a/js/booking.js
+++ b/js/booking.js
@@ -371,11 +371,26 @@
   const getExtrasCheckboxes = () => addonList.querySelectorAll('input[type="checkbox"]');
 
   const updateServiceSelection = (pkg) => {
-    if (!pkg) {
+    let desiredService = '';
+
+    if (pkg && pkg.service) {
+      desiredService = pkg.service;
+    } else {
+      const selectedIndex = packageSelect.selectedIndex;
+      if (selectedIndex >= 0) {
+        const selectedOption = packageSelect.options[selectedIndex];
+        if (selectedOption && selectedOption.dataset.service) {
+          desiredService = selectedOption.dataset.service;
+        }
+      }
+    }
+
+    if (!desiredService) {
       return;
     }
+
     const match = Array.from(serviceSelect.options).find(
-      (option) => option.value === pkg.service
+      (option) => option.value === desiredService
     );
     if (match) {
       serviceSelect.value = match.value;


### PR DESCRIPTION
## Summary
- allow the booking script to populate packages and extras even if the vehicle database fails to load
- guard the make/model lookup helpers so they degrade gracefully and update the copy when lookup is unavailable
- keep totals, hidden fields, and add-on pricing in sync with the adjusted lookup behaviour

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d7e929b42c833385fc67e280a6f04a