### PR TITLE
Prioritize instant quote experience on contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -43,82 +43,41 @@
   <!-- MAIN -->
   <main class="wrap main-content" id="book">
 
-    <!-- Intro (dark band) -->
-    <section class="section-dark contact-cta" style="margin-top:18px;">
-      <div class="contact-cta__content">
-        <p class="contact-cta__eyebrow">Polished &amp; Pristine — Darlington &amp; North East</p>
+    <section class="instant-quote-hero">
+      <div class="instant-quote-hero__copy">
+        <span class="instant-quote-badge">⚡ Instant quote</span>
         <h1>Contact / Book</h1>
-        <p class="lede">Choose the quickest route to a confirmed slot or tailored quote.</p>
-        <div class="contact-cta__actions">
+        <p class="lede">Drop your vehicle details and we’ll respond within minutes during open hours — no email tennis or waiting around.</p>
+        <div class="instant-quote-actions">
           <a href="tel:07468286651" class="btn btn-primary">Call 07468 286651</a>
           <a href="https://wa.me/447468286651" class="btn btn-outline">WhatsApp message</a>
         </div>
-        <p class="muted contact-cta__note">Prefer email? Use the booking form below — we respond within a working day with availability and clear pricing.</p>
-      </div>
-      <div class="contact-cta__card">
-        <h2>What to expect</h2>
-        <ul>
-          <li><strong>Friendly consultation:</strong> quick chat to confirm vehicle, condition and goals.</li>
-          <li><strong>Transparent pricing:</strong> no hidden fees — every option explained before you book.</li>
-          <li><strong>Flexible scheduling:</strong> mobile visits across Darlington, Teesside and County Durham.</li>
+        <ul class="instant-quote-points">
+          <li><span>🚗</span><div><strong>Vehicle-matched pricing:</strong> the quote adjusts to the exact make, model and variant you select.</div></li>
+          <li><span>🛠️</span><div><strong>Hands-on advice:</strong> quick chat to confirm condition, goals and ideal package with zero guesswork.</div></li>
+          <li><span>📆</span><div><strong>Fast scheduling:</strong> we lock in dates via call or WhatsApp — no endless back-and-forth.</div></li>
         </ul>
-        <div class="contact-cta__hours">
-          <span>📅</span>
-          <div>
-            <strong>Typical response hours</strong>
-            <p>Mon–Sat 8am–7pm</p>
+        <div class="instant-quote-meta">
+          <div class="instant-quote-hours">
+            <span>📅</span>
+            <div>
+              <strong>Typical response hours</strong>
+              <p>Mon–Sat 8am–7pm</p>
+            </div>
+          </div>
+          <div class="instant-quote-meta-card">
+            <strong>Area covered</strong>
+            <p>Mobile visits across Darlington, Teesside and County Durham.</p>
           </div>
         </div>
       </div>
-    </section>
-
-    <!-- Two-column content -->
-    <section class="cards small-gap" style="margin:22px 0 0 0;">
-      <article class="card">
-        <h2>✅ Complete vehicle lookup</h2>
-        <p class="muted">
-          Our booking form is powered by a <strong>400+ vehicle database</strong> covering more than 20 popular UK manufacturers.
-          Select the make, model and year and we instantly detect the <em>exact size category</em> – no guesswork.
-        </p>
-        <p class="muted">Every major brand is covered: Audi, BMW, Mercedes, Ford, Vauxhall, VW and many more.</p>
-      </article>
-      <article class="card">
-        <h2>📊 Smart pricing engine</h2>
-        <p class="muted">
-          Pricing automatically adjusts to the true vehicle size, your chosen package (valet, correction or coatings) and the vehicle’s condition.
-          Extras such as clay bar treatment, engine bay detail or ceramic upgrades are added transparently to the running total.
-        </p>
-        <div class="muted" style="margin-top:12px;">
-          <strong>Guideline size-based ranges</strong>
-          <ul style="margin:8px 0 0 18px;">
-            <li>Small cars: £45–£150</li>
-            <li>Medium cars: £55–£180</li>
-            <li>Large cars: £65–£210</li>
-            <li>SUVs: £75–£250</li>
-            <li>Vans: £95–£320</li>
-          </ul>
-          <p style="margin:10px 0 0;">Final quote depends on the package (mini/full valet, paint correction, ceramic coating) and condition.</p>
-        </div>
-      </article>
-      <article class="card">
-        <h2>🗓️ Frictionless booking flow</h2>
-        <p class="muted">
-          Choose your vehicle, service package and any add-ons, then pick a date and supply your details.
-          The form shows the running total before you confirm, so you know the investment before we arrive.
-        </p>
-        <p class="muted">The layout is optimised for one-handed use on mobile with fast-loading pages and smooth transitions.</p>
-      </article>
-    </section>
-
-    <!-- Two-column content -->
-    <section class="cards small-gap" style="margin-top:22px; grid-template-columns:1fr;">
-      <!-- FORM (FormSubmit wired) -->
-      <article class="card">
+      <div class="instant-quote-card">
         <h2>Get an instant quote</h2>
-        <p class="muted" style="margin-top:6px;">Start with your vehicle and service choice — we'll ask for your contact details at the end.</p>
+        <p class="muted">Start with your vehicle and package — the pricing updates as you choose options.</p>
 
         <form action="https://formsubmit.co/b89300d152399ad939e7db161cbb0cfa"
-              method="POST" enctype="multipart/form-data" style="margin-top:10px;"
+              method="POST" enctype="multipart/form-data"
+              class="instant-quote-form"
               data-booking-form>
           <!-- FormSubmit controls -->
           <input type="hidden" name="_next" value="https://polishedandpristine.co.uk/thank-you.html">
@@ -133,153 +92,171 @@
           <input type="hidden" name="service_package" id="servicePackageHidden">
           <input type="hidden" name="selected_extras" id="selectedExtrasHidden">
           <input type="hidden" name="calculated_total" id="calculatedTotalHidden">
+          <input type="hidden" name="service" id="serviceHidden">
           <!-- Honeypot (spam trap) -->
-          <input type="text" name="_honey" style="display:none">
+          <input type="text" name="_honey" class="instant-quote-honeypot">
 
-          <div style="display:grid; grid-template-columns:repeat(2, minmax(0,1fr)); gap:12px;">
-            <div style="grid-column:1/-1;">
-              <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:12px;">
-                <div>
-                  <label for="vehicleMake">Vehicle make</label>
-                  <select id="vehicleMake" required
-                          style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
-                    <option value="">Select make</option>
-                  </select>
-                </div>
-                <div>
-                  <label for="vehicleModel">Model</label>
-                  <select id="vehicleModel" required disabled
-                          style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
-                    <option value="">Select model</option>
-                  </select>
-                </div>
-                <div>
-                  <label for="vehicleVariant">Year / variant</label>
-                  <select id="vehicleVariant" required disabled
-                          style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
-                    <option value="">Select year / variant</option>
-                  </select>
-                </div>
-                <div>
-                  <label for="vehicleCategoryDisplay">Size category</label>
-                  <input id="vehicleCategoryDisplay" type="text" readonly placeholder="Select year / variant" data-category=""
-                         style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#111b2f; color:#e5e7eb; margin-top:6px;">
-                </div>
-                <div>
-                  <label for="vehicleCondition">Vehicle condition</label>
-                  <select id="vehicleCondition" required
-                          style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
-                    <option value="">Select condition</option>
-                    <option value="Excellent">Excellent (new / ceramic-ready)</option>
-                    <option value="Good">Good (light marring)</option>
-                    <option value="Needs correction">Needs correction (swirls, scratches)</option>
-                    <option value="Severe correction">Severe correction (oxidation / heavy defects)</option>
-                  </select>
-                </div>
+          <div class="instant-quote-form__section">
+            <div class="instant-quote-form__columns">
+              <div class="instant-quote-form__field">
+                <label for="vehicleMake">Vehicle make</label>
+                <select id="vehicleMake" required>
+                  <option value="">Select make</option>
+                </select>
+              </div>
+              <div class="instant-quote-form__field">
+                <label for="vehicleModel">Model</label>
+                <select id="vehicleModel" required disabled>
+                  <option value="">Select model</option>
+                </select>
+              </div>
+              <div class="instant-quote-form__field">
+                <label for="vehicleVariant">Year / variant</label>
+                <select id="vehicleVariant" required disabled>
+                  <option value="">Select year / variant</option>
+                </select>
+              </div>
+              <div class="instant-quote-form__field">
+                <label for="vehicleCategoryDisplay">Size category</label>
+                <input id="vehicleCategoryDisplay" type="text" readonly placeholder="Select year / variant" data-category="">
+              </div>
+              <div class="instant-quote-form__field">
+                <label for="vehicleCondition">Vehicle condition</label>
+                <select id="vehicleCondition" required>
+                  <option value="">Select condition</option>
+                  <option value="Excellent">Excellent (new / ceramic-ready)</option>
+                  <option value="Good">Good (light marring)</option>
+                  <option value="Needs correction">Needs correction (swirls, scratches)</option>
+                  <option value="Severe correction">Severe correction (oxidation / heavy defects)</option>
+                </select>
               </div>
             </div>
-            <div style="grid-column:1/-1; margin-top:4px; display:grid; gap:12px;">
-              <div>
+
+            <div class="instant-quote-form__stack">
+              <div class="instant-quote-form__field">
                 <label for="servicePackage">Choose a package</label>
-                <select id="servicePackage" required
-                        style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                <select id="servicePackage" required>
                   <option value="">Select package (auto-pricing)</option>
                 </select>
-                <p class="muted" style="margin:6px 0 0; font-size:0.9rem;">Base prices adjust automatically to your detected vehicle size. Choose the package closest to what you need and we’ll confirm availability.</p>
+                <div class="instant-quote-service">
+                  <span>Focus:</span>
+                  <strong data-service-display>Choose a package to see the focus area.</strong>
+                </div>
+                <p class="muted instant-quote-hint">Base prices adjust automatically to your detected vehicle size. Pick the package closest to what you need and we’ll confirm availability.</p>
               </div>
-              <fieldset style="border:1px solid #2a3346; border-radius:10px; padding:12px;">
-                <legend style="padding:0 6px; font-size:0.95rem;">Optional add-ons</legend>
-                <p class="muted" style="margin:0 0 8px; font-size:0.9rem;">Tick extras for protection or deep-clean elements. Prices below already include the size-based adjustment.</p>
-                <div data-addon-list style="display:grid; gap:8px;"></div>
+
+              <fieldset class="instant-quote-form__extras">
+                <legend>Optional add-ons</legend>
+                <p class="muted">Tick extras for protection or deep-clean elements. Prices already include the size-based adjustment.</p>
+                <div data-addon-list class="instant-quote-extras"></div>
               </fieldset>
-              <div style="background:#111b2f; border:1px solid #2a3346; border-radius:10px; padding:12px; display:flex; flex-direction:column; gap:6px;">
+
+              <div class="instant-quote-total">
                 <strong>Total estimate</strong>
-                <div data-total-display style="font-size:1.4rem; font-weight:600;">Select vehicle &amp; package</div>
-                <ul data-total-breakdown style="list-style:none; padding:0; margin:0; display:grid; gap:2px; font-size:0.9rem;">
+                <div data-total-display class="instant-quote-total__figure">Select vehicle &amp; package</div>
+                <ul data-total-breakdown class="instant-quote-total__list">
                   <li data-total-base class="muted">Base package: —</li>
                   <li data-total-condition class="muted">Condition uplift: —</li>
                   <li data-total-extras class="muted">Extras: —</li>
                 </ul>
-                <p class="muted" style="margin:0; font-size:0.9rem;" data-total-note>Totals reflect the package price, condition uplift and any extras. Final invoice is confirmed after inspection.</p>
+                <p class="muted instant-quote-total__note" data-total-note>Totals reflect the package price, condition uplift and any extras. Final invoice is confirmed after inspection.</p>
               </div>
             </div>
-            <div>
-              <label for="service">Service</label>
-              <select id="service" name="service" required
-                      style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
-                <option value="">Select service</option>
-                <option value="Ceramic coating (polish included)">Ceramic coating (polish included)</option>
-                <option value="Paint correction">Paint correction</option>
-                <option value="PPF">PPF</option>
-                <option value="Valeting / Interior">Valeting / Interior</option>
-                <option value="Other / Advice">Other / Advice</option>
-              </select>
-            </div>
 
-            <div style="grid-column:1/-1;">
+            <div class="instant-quote-form__field">
               <label for="dates">Preferred dates/times</label>
-              <input id="dates" name="dates"
-                     style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+              <input id="dates" name="dates">
             </div>
 
-            <div style="grid-column:1/-1;">
+            <div class="instant-quote-form__field instant-quote-form__field--full">
               <label for="message">Notes</label>
-              <textarea id="message" name="message" rows="5"
-                        style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;"
-                        placeholder="Tell us about the car, defects you see, goals and budget."></textarea>
+              <textarea id="message" name="message" rows="5" placeholder="Tell us about the car, defects you see, goals and budget."></textarea>
             </div>
 
-            <div style="grid-column:1/-1; margin-top:4px;">
-              <div class="muted" style="margin-bottom:4px; font-size:0.9rem;">Almost done — add your details so we can confirm the quote.</div>
-              <div style="display:grid; grid-template-columns:repeat(2, minmax(0,1fr)); gap:12px;">
-                <div>
+            <div class="instant-quote-form__field-group">
+              <div class="muted instant-quote-hint">Almost done — add your details so we can confirm the quote.</div>
+              <div class="instant-quote-form__columns">
+                <div class="instant-quote-form__field">
                   <label for="name">Name</label>
-                  <input id="name" name="name" required
-                         style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                  <input id="name" name="name" required>
                 </div>
-                <div>
+                <div class="instant-quote-form__field">
                   <label for="email">Email</label>
-                  <input id="email" name="email" type="email" required
-                         style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                  <input id="email" name="email" type="email" required>
                 </div>
-                <div>
+                <div class="instant-quote-form__field">
                   <label for="phone">Phone</label>
-                  <input id="phone" name="phone" type="tel"
-                         style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                  <input id="phone" name="phone" type="tel">
                 </div>
-                <div>
+                <div class="instant-quote-form__field">
                   <label for="postcode">Postcode</label>
-                  <input id="postcode" name="postcode"
-                         style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                  <input id="postcode" name="postcode">
                 </div>
-                <div style="grid-column:1/-1;">
+                <div class="instant-quote-form__field instant-quote-form__field--full">
                   <label for="reg">Vehicle reg</label>
-                  <input id="reg" name="reg"
-                         style="width:100%; padding:10px; border-radius:8px; border:1px solid #2a3346; background:#0f182b; color:#e5e7eb; margin-top:6px;">
+                  <input id="reg" name="reg">
                 </div>
               </div>
             </div>
 
-            <div style="grid-column:1/-1; display:flex; align-items:center; gap:8px;">
+            <div class="instant-quote-form__consent">
               <input id="consent" name="consent" type="checkbox" required>
               <label for="consent" class="muted">I agree to be contacted regarding my enquiry and accept the <a href="/privacy-policy.html">Privacy Policy</a>.</label>
             </div>
           </div>
 
-          <div style="margin-top:12px; display:flex; gap:10px; flex-wrap:wrap;">
+          <div class="instant-quote-form__actions">
             <button type="submit" class="btn btn-primary">Send request</button>
-            <a class="btn btn-outline" href="mailto:info@polishedandpristine.co.uk">Email instead</a>
-            <a class="btn btn-outline" href="tel:07468286651">Call instead</a>
+            <a class="btn btn-outline" href="tel:07468286651">Call now</a>
+            <a class="btn btn-outline" href="https://wa.me/447468286651">Share photos on WhatsApp</a>
           </div>
 
-          <p class="muted" style="margin-top:10px;">Prefer WhatsApp? Message us on <a href="tel:07468286651">07468 286651</a> and include your reg &amp; postcode. We’ll confirm the package, condition uplift and extras before booking you in.</p>
+          <p class="muted instant-quote-form__note">Prefer WhatsApp? Message us on <a href="tel:07468286651">07468 286651</a> with your reg &amp; postcode — we’ll confirm the package, condition uplift and extras straight away.</p>
         </form>
-      </article>
+      </div>
+    </section>
 
-      <!-- DETAILS -->
+    <section class="cards small-gap instant-quote-support">
       <article class="card">
+        <h2>✅ Complete vehicle lookup</h2>
+        <p class="muted">
+          Our booking form is powered by a <strong>400+ vehicle database</strong> covering more than 20 popular UK manufacturers.
+          Select the make, model and year and we instantly detect the <em>exact size category</em> – no guesswork.
+        </p>
+        <p class="muted">Every major brand is covered: Audi, BMW, Mercedes, Ford, Vauxhall, VW and many more.</p>
+      </article>
+      <article class="card">
+        <h2>📊 Smart pricing engine</h2>
+        <p class="muted">
+          Pricing automatically adjusts to the true vehicle size, your chosen package (valet, correction or coatings) and the vehicle’s condition.
+          Extras such as clay bar treatment, engine bay detail or ceramic upgrades are added transparently to the running total.
+        </p>
+        <div class="muted instant-quote-support__list">
+          <strong>Guideline size-based ranges</strong>
+          <ul>
+            <li>Small cars: £45–£150</li>
+            <li>Medium cars: £55–£180</li>
+            <li>Large cars: £65–£210</li>
+            <li>SUVs: £75–£250</li>
+            <li>Vans: £95–£320</li>
+          </ul>
+          <p>Final quote depends on the package (mini/full valet, paint correction, ceramic coating) and condition.</p>
+        </div>
+      </article>
+      <article class="card">
+        <h2>🗓️ Frictionless booking flow</h2>
+        <p class="muted">
+          Choose your vehicle, service package and any add-ons, then pick a date and supply your details.
+          The form shows the running total before you confirm, so you know the investment before we arrive.
+        </p>
+        <p class="muted">Optimised for one-handed use on mobile with fast-loading pages and smooth transitions.</p>
+      </article>
+    </section>
+
+    <section class="cards small-gap contact-details-grid">
+      <article class="card contact-details-card">
         <h2>Contact details</h2>
-        <p class="muted" style="margin-top:6px;">
+        <p class="muted">
           <strong>Polished &amp; Pristine</strong><br>
           3 Appleby Close, Darlington — DL1 4AJ<br>
           <a href="tel:07468286651">07468 286651</a><br>
@@ -294,7 +271,8 @@
       <h2 class="cta-title">Need a quick opinion first?</h2>
       <p class="muted">Send a couple of photos — we’ll let you know if it’s a one-stage polish, multi-stage correction or PPF situation.</p>
       <div class="cta-actions">
-        <a class="btn btn-primary" href="mailto:info@polishedandpristine.co.uk">Email photos</a>
+        <a class="btn btn-primary" href="https://wa.me/447468286651">WhatsApp photos</a>
+        <a class="btn btn-outline" href="mailto:info@polishedandpristine.co.uk">Email photos</a>
         <a class="btn btn-outline" href="/tips.html">Read our advice</a>
       </div>
     </section>

--- a/css/style.css
+++ b/css/style.css
@@ -93,73 +93,321 @@ a { color:inherit; text-decoration:none; }
 .section-dark .muted { color:#e5e7eb; }
 .section-dark h1, .section-dark h2, .section-dark h3 { color:#fff; }
 
-/* Contact CTA */
-.contact-cta {
+/* Contact instant quote */
+.instant-quote-hero {
+  position:relative;
+  margin-top:18px;
+  padding:34px;
+  border-radius:var(--radius);
+  background:radial-gradient(circle at top right, rgba(37,99,235,0.35), transparent 55%),
+             radial-gradient(circle at bottom left, rgba(250,204,21,0.18), transparent 60%),
+             linear-gradient(180deg, var(--panel) 0%, #091326 100%);
   display:grid;
-  gap:28px;
-  grid-template-columns: minmax(0,1.6fr) minmax(0,1fr);
+  grid-template-columns:minmax(0,1fr) minmax(0,1.05fr);
+  gap:32px;
   align-items:stretch;
+  overflow:hidden;
 }
-.contact-cta__eyebrow {
-  text-transform:uppercase;
-  letter-spacing:0.14em;
+.instant-quote-hero::before {
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at 20% 20%, rgba(250,204,21,0.12), transparent 45%);
+  pointer-events:none;
+}
+.instant-quote-hero__copy {
+  position:relative;
+  z-index:1;
+  display:flex;
+  flex-direction:column;
+  gap:20px;
+}
+.instant-quote-badge {
+  align-self:flex-start;
+  background:rgba(250,204,21,0.18);
+  color:var(--brand-gold);
+  padding:6px 14px;
+  border-radius:999px;
+  font-weight:700;
   font-size:0.75rem;
-  color:rgba(229,231,235,0.7);
-  margin:0 0 12px;
+  letter-spacing:0.16em;
+  text-transform:uppercase;
 }
-.contact-cta__actions {
+.instant-quote-actions {
   display:flex;
   flex-wrap:wrap;
   gap:12px;
-  margin:24px 0 18px;
 }
-.contact-cta__note {
-  max-width:440px;
-}
-.contact-cta__card {
-  background:rgba(15,26,45,0.9);
-  border:1px solid rgba(250,204,21,0.25);
-  border-radius:14px;
-  padding:22px;
-  box-shadow:0 12px 28px rgba(0,0,0,0.45);
-  display:flex;
-  flex-direction:column;
-  gap:16px;
-}
-.contact-cta__card ul {
+.instant-quote-points {
   list-style:none;
   margin:0;
   padding:0;
   display:grid;
-  gap:10px;
-  color:var(--muted);
+  gap:12px;
 }
-.contact-cta__card li strong {
-  color:#fff;
-}
-.contact-cta__hours {
+.instant-quote-points li {
   display:flex;
   gap:12px;
-  align-items:center;
+  align-items:flex-start;
+  background:rgba(12,19,35,0.85);
+  border:1px solid rgba(250,204,21,0.22);
+  border-radius:14px;
   padding:12px 14px;
-  background:rgba(17,24,39,0.85);
-  border-radius:12px;
-  border:1px solid rgba(250,204,21,0.2);
+  box-shadow:0 14px 32px rgba(0,0,0,0.35);
 }
-.contact-cta__hours span {
+.instant-quote-points span {
   font-size:1.4rem;
+  line-height:1;
 }
-.contact-cta__hours p {
-  margin:4px 0 0;
+.instant-quote-meta {
+  display:grid;
+  gap:14px;
+  grid-template-columns:repeat(auto-fit, minmax(220px,1fr));
+}
+.instant-quote-hours,
+.instant-quote-meta-card {
+  background:rgba(10,17,30,0.85);
+  border:1px solid rgba(250,204,21,0.2);
+  border-radius:14px;
+  padding:16px;
+  box-shadow:0 12px 26px rgba(0,0,0,0.35);
+}
+.instant-quote-hours {
+  display:flex;
+  gap:12px;
+  align-items:flex-start;
+}
+.instant-quote-hours span {
+  font-size:1.5rem;
+}
+.instant-quote-card {
+  position:relative;
+  z-index:1;
+  background:rgba(8,15,28,0.92);
+  border:1px solid rgba(250,204,21,0.28);
+  border-radius:20px;
+  padding:26px;
+  box-shadow:0 22px 42px rgba(0,0,0,0.55);
+}
+.instant-quote-card::before {
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  background:linear-gradient(130deg, rgba(250,204,21,0.06), transparent 55%);
+  pointer-events:none;
+}
+.instant-quote-form {
+  display:flex;
+  flex-direction:column;
+  gap:18px;
+}
+.instant-quote-form label {
+  font-weight:600;
+  font-size:0.95rem;
+  color:#f1f5f9;
+}
+.instant-quote-form input,
+.instant-quote-form select,
+.instant-quote-form textarea {
+  width:100%;
+  padding:11px 12px;
+  border-radius:10px;
+  border:1px solid #2a3346;
+  background:#0f182b;
+  color:#e5e7eb;
+  font-size:0.95rem;
+}
+.instant-quote-form select:disabled {
+  opacity:0.6;
+}
+.instant-quote-form textarea {
+  min-height:120px;
+  resize:vertical;
+}
+.instant-quote-form input::placeholder,
+.instant-quote-form textarea::placeholder {
+  color:rgba(229,231,235,0.65);
+}
+.instant-quote-form__section {
+  display:grid;
+  gap:18px;
+}
+.instant-quote-form__columns {
+  display:grid;
+  gap:12px;
+  grid-template-columns:repeat(auto-fit, minmax(180px,1fr));
+}
+.instant-quote-form__field {
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.instant-quote-form__field--full {
+  grid-column:1/-1;
+}
+.instant-quote-form__stack {
+  display:grid;
+  gap:14px;
+}
+.instant-quote-service {
+  margin-top:8px;
+  display:flex;
+  gap:8px;
+  align-items:center;
+  background:rgba(14,24,40,0.85);
+  border:1px solid rgba(250,204,21,0.24);
+  border-radius:999px;
+  padding:6px 12px;
+  font-size:0.9rem;
   color:var(--muted);
+}
+.instant-quote-service span {
+  font-weight:700;
+  text-transform:uppercase;
+  letter-spacing:0.12em;
+  font-size:0.7rem;
+  color:var(--brand-gold);
+}
+.instant-quote-hint {
+  font-size:0.9rem;
+}
+.instant-quote-form__extras {
+  border:1px solid #2a3346;
+  border-radius:14px;
+  padding:14px;
+  background:rgba(9,15,27,0.88);
+}
+.instant-quote-form__extras legend {
+  padding:0 6px;
+  font-size:0.95rem;
+  font-weight:600;
+  color:#f8fafc;
+}
+.instant-quote-form__extras p {
+  margin:0 0 10px;
+  font-size:0.9rem;
+}
+.instant-quote-extras {
+  display:grid;
+  gap:10px;
+}
+.instant-quote-extras__title {
+  font-weight:600;
+  color:#f8fafc;
+}
+.instant-quote-extras__price {
+  font-size:0.9rem;
+}
+.instant-quote-extras label {
+  display:grid;
+  grid-template-columns:auto 1fr;
+  gap:10px;
+  align-items:flex-start;
+  background:rgba(12,21,36,0.85);
+  border:1px solid rgba(250,204,21,0.18);
+  border-radius:12px;
+  padding:10px 12px;
+  cursor:pointer;
+}
+.instant-quote-extras input[type="checkbox"] {
+  margin-top:4px;
+}
+.instant-quote-total {
+  background:#111b2f;
+  border:1px solid #2a3346;
+  border-radius:14px;
+  padding:16px;
+  display:grid;
+  gap:8px;
+}
+.instant-quote-total__figure {
+  font-size:1.5rem;
+  font-weight:700;
+}
+.instant-quote-total__list {
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:4px;
+  font-size:0.92rem;
+}
+.instant-quote-total__note {
+  margin:0;
+  font-size:0.9rem;
+}
+.instant-quote-form__field-group {
+  display:grid;
+  gap:10px;
+}
+.instant-quote-form__consent {
+  display:flex;
+  gap:10px;
+  align-items:flex-start;
+  font-size:0.9rem;
+}
+.instant-quote-form__consent input {
+  margin-top:4px;
+}
+.instant-quote-form__actions {
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+}
+.instant-quote-form__note {
+  margin:0;
+  font-size:0.9rem;
+}
+.instant-quote-honeypot {
+  position:absolute;
+  left:-9999px;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+}
+.instant-quote-support {
+  margin-top:28px;
+}
+.instant-quote-support__list ul {
+  margin:8px 0 0 18px;
+  padding:0;
+}
+.instant-quote-support__list p {
+  margin:10px 0 0;
+}
+.contact-details-grid {
+  margin-top:24px;
+  grid-template-columns:1fr;
+}
+.contact-details-card {
+  padding:20px;
 }
 
 @media (max-width:900px) {
-  .contact-cta {
+  .instant-quote-hero {
+    grid-template-columns:1fr;
+    padding:28px;
+  }
+  .instant-quote-card {
+    order:-1;
+  }
+  .instant-quote-actions {
+    justify-content:flex-start;
+  }
+  .instant-quote-meta {
     grid-template-columns:1fr;
   }
-  .contact-cta__card {
-    order:-1;
+}
+
+@media (max-width:620px) {
+  .instant-quote-form__columns {
+    grid-template-columns:1fr;
+  }
+  .instant-quote-form__actions {
+    flex-direction:column;
+    align-items:stretch;
   }
 }
 

--- a/js/booking.js
+++ b/js/booking.js
@@ -9,7 +9,7 @@
   const variantSelect = form.querySelector('#vehicleVariant');
   const conditionSelect = form.querySelector('#vehicleCondition');
   const packageSelect = form.querySelector('#servicePackage');
-  const serviceSelect = form.querySelector('#service');
+  const serviceField = form.querySelector('#serviceHidden');
   const addonList = form.querySelector('[data-addon-list]');
   const totalDisplay = form.querySelector('[data-total-display]');
   const totalNote = form.querySelector('[data-total-note]');
@@ -18,6 +18,7 @@
   const totalExtras = form.querySelector('[data-total-extras]');
   const defaultTotalNote = totalNote ? totalNote.textContent : '';
   const categoryDisplay = form.querySelector('#vehicleCategoryDisplay');
+  const serviceDisplay = form.querySelector('[data-service-display]');
 
   const hiddenMake = form.querySelector('#vehicleMakeHidden');
   const hiddenModel = form.querySelector('#vehicleModelHidden');
@@ -27,6 +28,7 @@
   const hiddenPackage = form.querySelector('#servicePackageHidden');
   const hiddenExtras = form.querySelector('#selectedExtrasHidden');
   const hiddenTotal = form.querySelector('#calculatedTotalHidden');
+  const hiddenService = form.querySelector('#serviceHidden');
 
   if (
     !makeSelect ||
@@ -34,7 +36,7 @@
     !variantSelect ||
     !conditionSelect ||
     !packageSelect ||
-    !serviceSelect ||
+    !serviceField ||
     !addonList ||
     !totalDisplay ||
     !totalBase ||
@@ -47,6 +49,7 @@
     !hiddenCategory ||
     !hiddenCondition ||
     !hiddenPackage ||
+    !hiddenService ||
     !hiddenExtras ||
     !hiddenTotal
   ) {
@@ -271,6 +274,7 @@
     hiddenVariant.value = variantSelect.value;
     hiddenCondition.value = conditionSelect.value;
     hiddenPackage.value = packageSelect.value;
+    hiddenService.value = serviceField.value;
   };
 
   const getCategory = () => categoryDisplay.dataset.category || categoryDisplay.value || '';
@@ -312,25 +316,19 @@
       const id = `addon-${extra.id}`;
       const wrapper = document.createElement('label');
       wrapper.setAttribute('for', id);
-      wrapper.style.display = 'grid';
-      wrapper.style.gridTemplateColumns = 'auto 1fr';
-      wrapper.style.alignItems = 'start';
-      wrapper.style.gap = '10px';
 
       const checkbox = document.createElement('input');
       checkbox.type = 'checkbox';
       checkbox.id = id;
       checkbox.dataset.extraId = extra.id;
       checkbox.dataset.extraLabel = extra.label;
-      checkbox.style.marginTop = '3px';
 
       const textWrap = document.createElement('div');
       const title = document.createElement('div');
       title.textContent = extra.label;
-      title.style.fontWeight = '600';
+      title.className = 'instant-quote-extras__title';
       const price = document.createElement('div');
-      price.className = 'muted';
-      price.style.fontSize = '0.9rem';
+      price.className = 'muted instant-quote-extras__price';
       price.dataset.priceDisplay = extra.id;
 
       textWrap.appendChild(title);
@@ -344,15 +342,20 @@
 
   const getExtrasCheckboxes = () => addonList.querySelectorAll('input[type="checkbox"]');
 
-  const updateServiceSelection = (pkg) => {
-    if (!pkg) {
+  const setServiceSummary = (pkg) => {
+    if (!serviceField) {
       return;
     }
-    const match = Array.from(serviceSelect.options).find(
-      (option) => option.value === pkg.service
-    );
-    if (match) {
-      serviceSelect.value = match.value;
+    if (!pkg) {
+      serviceField.value = '';
+      if (serviceDisplay) {
+        serviceDisplay.textContent = 'Choose a package to see the focus area.';
+      }
+      return;
+    }
+    serviceField.value = pkg.service;
+    if (serviceDisplay) {
+      serviceDisplay.textContent = pkg.service;
     }
   };
 
@@ -375,6 +378,7 @@
   const updateTotal = () => {
     const category = getCategory();
     const selectedPackage = getSelectedPackage();
+    setServiceSummary(selectedPackage);
     const packageBase = selectedPackage
       ? resolvePrice(selectedPackage.pricing, category)
       : 0;
@@ -472,6 +476,7 @@
   populateMakes();
   populatePackages();
   renderExtras();
+  setServiceSummary(null);
   clearCategory();
 
   makeSelect.addEventListener('change', () => {
@@ -515,7 +520,7 @@
   packageSelect.addEventListener('change', () => {
     updateHiddenFields();
     const pkg = getSelectedPackage();
-    updateServiceSelection(pkg);
+    setServiceSummary(pkg);
     updateTotal();
   });
 


### PR DESCRIPTION
## Summary
- rebuild the contact hero to surface the instant quote form first, emphasising rapid responses and quick-call actions
- refresh supporting copy, CTA buttons and layout styling for the quote form, packages and contact details
- streamline booking logic to mirror the merged package/service workflow and restyle extras presentation

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d85685d87c8333bbc04a746cf64a4d