### PR TITLE
Hide vehicle condition field for valeting packages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -120,9 +120,9 @@
                 <label for="vehicleCategoryDisplay">Size category</label>
                 <input id="vehicleCategoryDisplay" type="text" readonly placeholder="Select year / variant" data-category="">
               </div>
-              <div class="instant-quote-form__field">
+              <div class="instant-quote-form__field" data-condition-wrapper hidden>
                 <label for="vehicleCondition">Vehicle condition</label>
-                <select id="vehicleCondition" required>
+                <select id="vehicleCondition">
                   <option value="">Select condition</option>
                   <option value="Excellent">Excellent (new / ceramic-ready)</option>
                   <option value="Good">Good (light marring)</option>


### PR DESCRIPTION
## Summary
- hide the vehicle condition selector until a correction or coating package is chosen
- update booking logic to mark packages that need condition details and adjust totals/notes accordingly

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d85b0ae2fc8333b39d8322fe9ed572