### PR TITLE
Disable vehicle condition field until required package is chosen

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -120,9 +120,9 @@
                 <label for="vehicleCategoryDisplay">Size category</label>
                 <input id="vehicleCategoryDisplay" type="text" readonly placeholder="Select year / variant" data-category="">
               </div>
-              <div class="instant-quote-form__field">
+              <div class="instant-quote-form__field" data-condition-wrapper>
                 <label for="vehicleCondition">Vehicle condition</label>
-                <select id="vehicleCondition" required>
+                <select id="vehicleCondition" disabled>
                   <option value="">Select condition</option>
                   <option value="Excellent">Excellent (new / ceramic-ready)</option>
                   <option value="Good">Good (light marring)</option>

--- a/js/booking.js
+++ b/js/booking.js
@@ -70,6 +70,7 @@
         label: 'Maintenance valet (exterior & interior)',
         service: 'Valeting / Interior',
         description: '2-3 hour maintenance detail ideal for well-kept cars.',
+        requiresCondition: false,
         pricing: {
           'Small Car': 55,
           'Medium Car': 65,
@@ -85,6 +86,7 @@
         label: 'Deep clean valet + gloss boost',
         service: 'Valeting / Interior',
         description: 'Full interior shampoo, steam clean and machine glaze.',
+        requiresCondition: false,
         pricing: {
           'Small Car': 95,
           'Medium Car': 110,
@@ -100,6 +102,7 @@
         label: 'Single-stage paint correction',
         service: 'Paint correction',
         description: 'Enhancement polish to remove light swirls and restore gloss.',
+        requiresCondition: true,
         pricing: {
           'Small Car': 220,
           'Medium Car': 260,
@@ -115,6 +118,7 @@
         label: 'Two-stage correction + 2yr ceramic',
         service: 'Ceramic coating (polish included)',
         description: 'Heavy correction, panel wipe and 2-year ceramic coating.',
+        requiresCondition: true,
         pricing: {
           'Small Car': 420,
           'Medium Car': 470,
@@ -130,6 +134,7 @@
         label: 'PPF partial front (bumper, bonnet, wings, mirrors)',
         service: 'PPF',
         description: 'Stone-chip protection film for the most exposed panels.',
+        requiresCondition: false,
         pricing: {
           'Small Car': 650,
           'Medium Car': 700,
@@ -268,11 +273,16 @@
     variantSelect.disabled = false;
   };
 
+  const isConditionFieldEnabled = () =>
+    Boolean(conditionSelect) && !conditionSelect.disabled;
+
   const updateHiddenFields = () => {
     hiddenMake.value = makeSelect.value;
     hiddenModel.value = modelSelect.value;
     hiddenVariant.value = variantSelect.value;
-    hiddenCondition.value = conditionSelect.value;
+    hiddenCondition.value = isConditionFieldEnabled()
+      ? conditionSelect.value
+      : 'Not required for selected package';
     hiddenPackage.value = packageSelect.value;
     hiddenService.value = serviceField.value;
   };
@@ -280,6 +290,9 @@
   const getCategory = () => categoryDisplay.dataset.category || categoryDisplay.value || '';
 
   const getConditionMultiplier = () => {
+    if (!isConditionFieldEnabled()) {
+      return 1;
+    }
     const multiplier = pricingConfig.conditionMultipliers[conditionSelect.value];
     return typeof multiplier === 'number'
       ? multiplier
@@ -359,6 +372,28 @@
     }
   };
 
+  const toggleConditionField = (selectedPackage) => {
+    if (!conditionSelect) {
+      return;
+    }
+    const requiresCondition = Boolean(
+      selectedPackage
+        ? selectedPackage.requiresCondition
+        : (getSelectedPackage() || {}).requiresCondition
+    );
+
+    conditionSelect.disabled = !requiresCondition;
+    conditionSelect.required = requiresCondition;
+
+    if (!requiresCondition) {
+      if (conditionSelect.value) {
+        conditionSelect.value = '';
+      }
+    }
+
+    updateHiddenFields();
+  };
+
   const updateExtrasPricingDisplay = () => {
     const category = getCategory();
     pricingConfig.extras.forEach((extra) => {
@@ -379,6 +414,8 @@
     const category = getCategory();
     const selectedPackage = getSelectedPackage();
     setServiceSummary(selectedPackage);
+    toggleConditionField(selectedPackage);
+    const conditionActive = isConditionFieldEnabled();
     const packageBase = selectedPackage
       ? resolvePrice(selectedPackage.pricing, category)
       : 0;
@@ -420,7 +457,9 @@
     }
 
     if (totalCondition) {
-      if (!conditionSelect.value) {
+      if (!conditionActive) {
+        totalCondition.textContent = 'Condition uplift: Not required for this package';
+      } else if (!conditionSelect.value) {
         totalCondition.textContent = 'Condition uplift: Waiting for condition';
       } else if (conditionMultiplier > 1) {
         const upliftValue = Math.max(0, adjustedBase - packageBase);
@@ -430,9 +469,11 @@
       }
     }
 
-    const multiplierLabel = conditionSelect.value
-      ? `${conditionSelect.value} condition`
-      : 'Condition not provided';
+    const multiplierLabel = !conditionActive
+      ? 'Condition not required'
+      : conditionSelect.value
+        ? `${conditionSelect.value} condition`
+        : 'Condition not provided';
 
     const extrasSummary = Array.from(getExtrasCheckboxes())
       .filter((checkbox) => checkbox.checked)
@@ -459,9 +500,11 @@
     hiddenTotal.value = formatCurrency(total);
 
     if (totalNote) {
-      totalNote.textContent = conditionSelect.value
-        ? 'Estimate = package price × condition uplift + extras. We confirm the figure after hands-on inspection.'
-        : 'Select a vehicle condition to confirm the uplift. Estimate currently assumes excellent condition.';
+      totalNote.textContent = !conditionActive
+        ? 'Estimate excludes condition uplift (not required for this package).'
+        : conditionSelect.value
+          ? 'Estimate = package price × condition uplift + extras. We confirm the figure after hands-on inspection.'
+          : 'Select a vehicle condition to confirm the uplift. Estimate currently assumes excellent condition.';
     }
   };
 
@@ -477,6 +520,7 @@
   populatePackages();
   renderExtras();
   setServiceSummary(null);
+  toggleConditionField(null);
   clearCategory();
 
   makeSelect.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- leave the vehicle condition selector visible but disabled until a correction or coating package is picked
- update the booking logic to treat the disabled state as "not required" and enable it when a qualifying package is selected

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d85b0ae2fc8333b39d8322fe9ed572