### PR TITLE
Keep vehicle condition selector visible until required

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -120,9 +120,9 @@
                 <label for="vehicleCategoryDisplay">Size category</label>
                 <input id="vehicleCategoryDisplay" type="text" readonly placeholder="Select year / variant" data-category="">
               </div>
-              <div class="instant-quote-form__field" data-condition-wrapper hidden>
+              <div class="instant-quote-form__field" data-condition-wrapper>
                 <label for="vehicleCondition">Vehicle condition</label>
-                <select id="vehicleCondition">
+                <select id="vehicleCondition" disabled>
                   <option value="">Select condition</option>
                   <option value="Excellent">Excellent (new / ceramic-ready)</option>
                   <option value="Good">Good (light marring)</option>

--- a/js/booking.js
+++ b/js/booking.js
@@ -276,14 +276,14 @@
     variantSelect.disabled = false;
   };
 
-  const isConditionFieldVisible = () =>
-    !conditionFieldWrapper || !conditionFieldWrapper.hidden;
+  const isConditionFieldActive = () =>
+    Boolean(conditionSelect) && !conditionSelect.disabled;
 
   const updateHiddenFields = () => {
     hiddenMake.value = makeSelect.value;
     hiddenModel.value = modelSelect.value;
     hiddenVariant.value = variantSelect.value;
-    hiddenCondition.value = isConditionFieldVisible()
+    hiddenCondition.value = isConditionFieldActive()
       ? conditionSelect.value
       : 'Not required for selected package';
     hiddenPackage.value = packageSelect.value;
@@ -293,7 +293,7 @@
   const getCategory = () => categoryDisplay.dataset.category || categoryDisplay.value || '';
 
   const getConditionMultiplier = () => {
-    if (!isConditionFieldVisible()) {
+    if (!isConditionFieldActive()) {
       return 1;
     }
     const multiplier = pricingConfig.conditionMultipliers[conditionSelect.value];
@@ -385,7 +385,8 @@
         : (getSelectedPackage() || {}).requiresCondition
     );
 
-    conditionFieldWrapper.hidden = !requiresCondition;
+    conditionFieldWrapper.hidden = false;
+    conditionSelect.disabled = !requiresCondition;
     conditionSelect.required = requiresCondition;
 
     if (!requiresCondition) {
@@ -418,7 +419,7 @@
     const selectedPackage = getSelectedPackage();
     setServiceSummary(selectedPackage);
     toggleConditionField(selectedPackage);
-    const conditionActive = isConditionFieldVisible();
+    const conditionActive = isConditionFieldActive();
     const packageBase = selectedPackage
       ? resolvePrice(selectedPackage.pricing, category)
       : 0;


### PR DESCRIPTION
## Summary
- keep the vehicle condition selector visible but initially disabled so visitors can see it before choosing a package
- update the booking logic to treat the disabled field as not required and enable it when a correction or coating package is selected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d85e55d3f083339edfece91c8e77b7