### PR TITLE
Scope mobile nav overlay styles to small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -473,12 +473,12 @@ a { color:inherit; text-decoration:none; }
   .mobile-toggle { display:block; }
   .brand-logo { width:48px; height:48px; }
   .hero { padding:22px; }
-}
 
-/* --- Mobile nav open --- */
-.main-nav.nav-open {
-  display:flex; position:fixed; left:0; top:72px; right:0;
-  background: var(--bg); flex-direction:column; padding:18px;
-  box-shadow:0 10px 30px rgba(0,0,0,0.5); z-index:60;
-  border-top:1px solid rgba(250,204,21,.25);
+  /* Mobile nav open */
+  .main-nav.nav-open {
+    display:flex; position:fixed; left:0; top:72px; right:0;
+    background: var(--bg); flex-direction:column; padding:18px;
+    box-shadow:0 10px 30px rgba(0,0,0,0.5); z-index:60;
+    border-top:1px solid rgba(250,204,21,.25);
+  }
 }

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         </div>
       </a>
 
-      <button id="mobileNavToggle" class="mobile-toggle" aria-label="Open menu">☰</button>
+      <button id="mobileNavToggle" class="mobile-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link nav-active">Home</a>
@@ -191,7 +191,21 @@
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
       if (btn && nav) {
-        btn.addEventListener('click', () => nav.classList.toggle('nav-open'));
+        const toggleNav = () => {
+          const isOpen = nav.classList.toggle('nav-open');
+          btn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        };
+
+        const handleResize = () => {
+          if (window.innerWidth > 980 && nav.classList.contains('nav-open')) {
+            nav.classList.remove('nav-open');
+            btn.setAttribute('aria-expanded', 'false');
+          }
+        };
+
+        btn.addEventListener('click', toggleNav);
+        window.addEventListener('resize', handleResize);
+        handleResize();
       }
     })();
   </script>


### PR DESCRIPTION
## Summary
- scope the `.main-nav.nav-open` overlay styles within the existing 980px breakpoint so they only apply on mobile
- enhance the mobile toggle script to manage `aria-expanded` and close the menu on resize beyond 980px

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d85e77a36483338f40965e83ba6b71