### PR TITLE
Add Google Analytics tag to site pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Page Not Found (404) — Polished &amp; Pristine (Darlington)</title>
   <meta name="description" content="Sorry, the page you’re looking for can’t be found. Head back to our services or contact us for help.">
   <meta name="robots" content="noindex,follow">

--- a/ceramic-coatings.html
+++ b/ceramic-coatings.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Ceramic Coatings Darlington — Long-Life Paint Protection | Polished & Pristine</title>
   <meta name="description" content="Professional ceramic coatings in Darlington. Hydrophobic, UV-resistant protection with 1, 3 and 5+ year options. Ideal after paint correction for lasting gloss.">
   <link rel="stylesheet" href="/css/style.css">

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Contact / Book — Polished & Pristine (Darlington)</title>
   <meta name="description" content="Contact Polished & Pristine — book a free assessment for ceramic coatings, paint correction and PPF in Darlington." />
   <link rel="stylesheet" href="/css/style.css">

--- a/gallery.html
+++ b/gallery.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Gallery — Before & After | Polished & Pristine (Darlington)</title>
   <meta name="description" content="Before & after images and short videos of paint correction, ceramic coatings (polish included) and PPF by Polished & Pristine in Darlington." />
   <link rel="stylesheet" href="/css/style.css">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Darlington Detailing — Ceramic Coatings (polish included), Paint Correction & PPF | Polished & Pristine</title>
   <meta name="description" content="Premium paint protection in Darlington: ceramic coatings (single-stage machine polish included), multi-stage paint correction and PPF. Free assessment and clear pricing.">
   <link rel="stylesheet" href="/css/style.css">

--- a/paint-correction.html
+++ b/paint-correction.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Paint Correction Darlington — Remove Swirls & Restore Gloss | Polished & Pristine</title>
   <meta name="description" content="Professional paint correction in Darlington. Remove swirl marks, light scratches and oxidation with safe multi-stage machine polishing. Free assessment & honest advice.">
   <link rel="stylesheet" href="/css/style.css">

--- a/ppf.html
+++ b/ppf.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Paint Protection Film (PPF) — Polished & Pristine (Darlington)</title>
   <meta name="description" content="PPF in Darlington — invisible, self-healing paint protection film for bumpers, sills, bonnets and full wraps. Quoted on inspection; typical high-impact packs from £600+." />
   <link rel="stylesheet" href="/css/style.css">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Privacy Policy — Polished &amp; Pristine (Darlington)</title>
   <meta name="description" content="Plain-English privacy policy for Polished & Pristine, including what we collect via our contact form (FormSubmit), why we collect it, and your UK GDPR rights.">
   <link rel="canonical" href="https://polishedandpristine.co.uk/privacy-policy.html">

--- a/services.html
+++ b/services.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Services — Ceramic Coatings (polish included), Paint Correction & PPF | Polished & Pristine (Darlington)</title>
   <meta name="description" content="Premium-first services in Darlington: ceramic coatings (single-stage machine polish included) from £200, paint correction from £150, PPF packs from £600+, plus valeting.">
   <link rel="canonical" href="https://polishedandpristine.co.uk/services.html">

--- a/thank-you.html
+++ b/thank-you.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Thank You — Polished &amp; Pristine (Darlington)</title>
   <meta name="description" content="Thanks for your message. We’ll get back to you as soon as possible. Based in Darlington, serving a ~25-mile radius.">
   <link rel="canonical" href="https://polishedandpristine.co.uk/thank-you.html">

--- a/tips.html
+++ b/tips.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Expert Advice — Aftercare & Detailing Tips | Polished & Pristine</title>
   <meta name="description" content="Aftercare and detailing tips from Polished & Pristine: maintenance washing, drying safely, decontamination schedule, ceramic coating care, and FAQs." />
   <link rel="stylesheet" href="/css/style.css">

--- a/valeting.html
+++ b/valeting.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-KHRJL722HX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-KHRJL722HX');
+  </script>
   <title>Valeting & Interior Cleaning — Polished & Pristine (Darlington)</title>
   <meta name="description" content="Valeting and interior deep clean services in Darlington. Steam sanitisation, stain removal, odour treatments and maintenance valets by Polished & Pristine." />
   <link rel="stylesheet" href="/css/style.css">


### PR DESCRIPTION
## Summary
- insert the Google tag manager snippet into the head of every HTML page so tracking runs site-wide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d865c800648333b2ecce9a5dc31d45