### PR TITLE
Replace booking terminology with instant quote phrasing

### DIFF
--- a/404.html
+++ b/404.html
@@ -65,7 +65,7 @@
       <div style="margin-top:24px; display:flex; gap:12px; justify-content:center; flex-wrap:wrap;">
         <a href="/services.html" class="btn btn-primary">Explore Services</a>
         <a href="/index.html" class="btn btn-outline">Back to Home</a>
-        <a href="/contact.html" class="btn btn-outline">Contact / Book</a>
+        <a href="/contact.html#instant-quote" class="btn btn-outline">Get instant quote</a>
       </div>
 
       <hr class="hr" style="margin:36px auto; max-width:720px;">

--- a/ceramic-coatings.html
+++ b/ceramic-coatings.html
@@ -91,7 +91,7 @@
       <p class="muted"><strong>Every ceramic package includes at least a single-stage machine polish</strong> to prepare the paint properly. Multi-stage correction is recommended where defects are heavier.</p>
       <p class="muted">Our coatings create a tough, glassy layer that bonds to your paintwork. You’ll see faster washing, stronger chemical & UV resistance, and deeper, longer-lasting gloss. Best results when applied after paint correction.</p>
       <div style="margin-top:12px;">
-        <a class="btn btn-primary" href="/contact.html#book">Get coating options</a>
+        <a class="btn btn-primary" href="/contact.html#instant-quote">Get coating options</a>
         <a class="btn btn-outline" href="/paint-correction.html" style="margin-left:10px;">Pair with paint correction</a>
       </div>
     </header>
@@ -152,7 +152,7 @@
     </div>
   </div>
   <div style="margin-top:12px;">
-    <a href="/contact.html#book" class="btn btn-primary">Request a coating quote</a>
+    <a href="/contact.html#instant-quote" class="btn btn-primary">Request a coating quote</a>
     <a href="/paint-correction.html" class="btn btn-outline" style="margin-left:10px;">See paint correction detail</a>
   </div>
 </section>
@@ -205,7 +205,7 @@
     <section class="card" style="margin-top:20px;">
       <h2>Ready for year-round gloss and protection?</h2>
       <p class="muted">Tell us your vehicle and goals — we’ll recommend the right coating and prep to match your budget and usage.</p>
-      <a class="btn btn-primary" href="/contact.html#book">Get started</a>
+      <a class="btn btn-primary" href="/contact.html#instant-quote">Get started</a>
     </section>
 
   </main>

--- a/complete_vehicle_database.js
+++ b/complete_vehicle_database.js
@@ -1,4 +1,4 @@
-// Complete UK Vehicle Database - Replace the vehicleDatabase object in your booking system with this
+// Complete UK Vehicle Database - Replace the vehicleDatabase object in your instant quote system with this
 // Audit note: currently covers 22 manufacturers. Frequently requested marques that are not yet
 // represented include Citroën, Fiat, Alfa Romeo, Lexus, Mitsubishi, Suzuki, Jeep, Porsche, Cupra,
 // Polestar, MG, DS Automobiles and Genesis.

--- a/contact.html
+++ b/contact.html
@@ -12,11 +12,11 @@
 
     gtag('config', 'G-KHRJL722HX');
   </script>
-  <title>Contact / Book — Polished & Pristine (Darlington)</title>
-  <meta name="description" content="Contact Polished & Pristine — book a free assessment for ceramic coatings, paint correction and PPF in Darlington." />
+  <title>Contact / Get Instant Quote — Polished & Pristine (Darlington)</title>
+  <meta name="description" content="Contact Polished & Pristine — get an instant quote for ceramic coatings, paint correction and PPF in Darlington." />
   <link rel="stylesheet" href="/css/style.css">
-  <meta property="og:title" content="Polished & Pristine — Contact / Book" />
-  <meta property="og:description" content="Book a free assessment or ask a question. Darlington & surrounding areas." />
+  <meta property="og:title" content="Polished & Pristine — Contact / Get Instant Quote" />
+  <meta property="og:description" content="Get an instant quote or ask a question. Darlington & surrounding areas." />
   <meta property="og:image" content="https://polishedandpristine.co.uk/images/og-image.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
 </head>
@@ -50,12 +50,12 @@
   </header>
 
   <!-- MAIN -->
-  <main class="wrap main-content" id="book">
+  <main class="wrap main-content" id="instant-quote">
 
     <section class="instant-quote-hero">
       <div class="instant-quote-hero__copy">
         <span class="instant-quote-badge">⚡ Instant quote</span>
-        <h1>Contact / Book</h1>
+        <h1>Contact / Get Instant Quote</h1>
         <p class="lede">Drop your vehicle details and we’ll respond within minutes during open hours — no email tennis or waiting around.</p>
         <div class="instant-quote-actions">
           <a href="tel:07468286651" class="btn btn-primary">Call 07468 286651</a>
@@ -87,7 +87,7 @@
         <form action="https://formsubmit.co/b89300d152399ad939e7db161cbb0cfa"
               method="POST" enctype="multipart/form-data"
               class="instant-quote-form"
-              data-booking-form>
+              data-instant-quote-form>
           <!-- FormSubmit controls -->
           <input type="hidden" name="_next" value="https://polishedandpristine.co.uk/thank-you.html">
           <input type="hidden" name="_subject" value="Website enquiry: Polished &amp; Pristine">
@@ -229,7 +229,7 @@
       <article class="card">
         <h2>✅ Complete vehicle lookup</h2>
         <p class="muted">
-          Our booking form is powered by a <strong>400+ vehicle database</strong> covering more than 20 popular UK manufacturers.
+          Our instant quote form is powered by a <strong>400+ vehicle database</strong> covering more than 20 popular UK manufacturers.
           Select the make, model and year and we instantly detect the <em>exact size category</em> – no guesswork.
         </p>
         <p class="muted">Every major brand is covered: Audi, BMW, Mercedes, Ford, Vauxhall, VW and many more.</p>
@@ -253,7 +253,7 @@
         </div>
       </article>
       <article class="card">
-        <h2>🗓️ Frictionless booking flow</h2>
+        <h2>🗓️ Frictionless instant quote flow</h2>
         <p class="muted">
           Choose your vehicle, service package and any add-ons, then pick a date and supply your details.
           The form shows the running total before you confirm, so you know the investment before we arrive.
@@ -326,7 +326,7 @@
 
   <!-- Mobile nav toggle -->
   <script src="/complete_vehicle_database.js"></script>
-  <script src="/js/booking.js"></script>
+  <script src="/js/instant-quote.js"></script>
   <script>
     (function(){
       const btn = document.getElementById('mobileNavToggle');

--- a/gallery.html
+++ b/gallery.html
@@ -101,7 +101,7 @@
         Tell us your reg and what finish you’re after. We’ll recommend the most effective route for your budget and goals.
       </p>
       <div class="cta-actions">
-        <a class="btn btn-primary" href="/contact.html#book">Book a free assessment</a>
+        <a class="btn btn-primary" href="/contact.html#instant-quote">Get instant quote</a>
         <a class="btn btn-outline" href="/services.html">Compare services</a>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -83,11 +83,11 @@
         <p class="lede">
           Premium paintwork results across Darlington &amp; Teesside.
           <strong>All ceramic coatings include a single-stage machine polish.</strong>
-          Book a free assessment for a clear, no-nonsense quote.
+          Get an instant quote and a clear, no-nonsense assessment.
         </p>
 
         <div class="hero-ctas">
-          <a href="/contact.html#book" class="btn btn-primary">Get a quote</a>
+          <a href="/contact.html#instant-quote" class="btn btn-primary">Get instant quote</a>
           <a href="/services.html" class="btn btn-outline">See packages</a>
         </div>
 
@@ -167,7 +167,7 @@
         We’ll assess paint condition and recommend the best route for your budget and goals.
       </p>
       <div class="cta-actions">
-        <a class="btn btn-primary" href="/contact.html#book">Book a free assessment</a>
+        <a class="btn btn-primary" href="/contact.html#instant-quote">Get instant quote</a>
         <a class="btn btn-outline" href="/services.html">Compare services</a>
       </div>
     </section>

--- a/js/instant-quote.js
+++ b/js/instant-quote.js
@@ -1,5 +1,5 @@
 (function () {
-  const form = document.querySelector('[data-booking-form]');
+  const form = document.querySelector('[data-instant-quote-form]');
   if (!form || typeof vehicleDatabase === 'undefined') {
     return;
   }

--- a/paint-correction.html
+++ b/paint-correction.html
@@ -95,7 +95,7 @@
       <h1>Paint Correction — remove swirls, restore deep gloss</h1>
       <p class="muted">We safely reduce defects like swirl marks, light scratches and oxidation with multi-stage machine polishing. Based in Darlington — serving nearby towns within ~25 miles.</p>
       <div style="margin-top:12px;">
-        <a class="btn btn-primary" href="/contact.html#book">Book a free paint assessment</a>
+        <a class="btn btn-primary" href="/contact.html#instant-quote">Get instant quote</a>
         <a class="btn btn-outline" href="#pricing" style="margin-left:10px;">See pricing guide</a>
       </div>
     </header>
@@ -184,7 +184,7 @@
         </div>
       </div>
       <div style="margin-top:12px;">
-        <a href="/contact.html#book" class="btn btn-primary">Request a paint correction quote</a>
+      <a href="/contact.html#instant-quote" class="btn btn-primary">Get instant paint correction quote</a>
         <a href="/ceramic-coatings.html" class="btn btn-outline" style="margin-left:10px;">See ceramic coating options</a>
       </div>
     </section>
@@ -224,8 +224,8 @@
     <!-- CTA -->
     <section class="card" style="margin-top:20px;">
       <h2>Ready to transform your paint?</h2>
-      <p class="muted">Book a free assessment. We’ll inspect the paint under lighting, explain expected results, and provide a clear quote.</p>
-      <a class="btn btn-primary" href="/contact.html#book">Book now</a>
+      <p class="muted">Get an instant quote with a free assessment. We’ll inspect the paint under lighting, explain expected results, and provide a clear price.</p>
+      <a class="btn btn-primary" href="/contact.html#instant-quote">Get instant quote</a>
     </section>
 
   </main>

--- a/ppf.html
+++ b/ppf.html
@@ -97,7 +97,7 @@
       </article>
     </section>
 
-    <!-- Pricing & booking -->
+    <!-- Pricing & instant quote -->
     <section class="services-preview" style="margin-top:22px;">
       <div class="grid-3">
         <article class="service-card">
@@ -110,9 +110,9 @@
             coverage, film and vehicle size.</p>
         </article>
         <article class="service-card">
-          <h2>Book PPF consult</h2>
+          <h2>Get instant PPF consult quote</h2>
           <p class="muted">Tell us your reg and priorities (chips, track use, motorway miles). We’ll outline options &amp; timescales.</p>
-          <a href="/contact.html#book" class="btn btn-primary" style="margin-top:8px;">Book consultation</a>
+          <a href="/contact.html#instant-quote" class="btn btn-primary" style="margin-top:8px;">Get instant quote</a>
         </article>
       </div>
     </section>
@@ -139,9 +139,9 @@
     <!-- CTA (dark band) -->
     <section class="cta-band section-dark" style="margin-top:30px;">
       <h2 class="cta-title">Ready to protect your paint?</h2>
-      <p class="muted">Book a no-obligation inspection. We’ll map the vulnerable zones and give a clear quote.</p>
+      <p class="muted">Get an instant quote with a no-obligation inspection. We’ll map the vulnerable zones and give a clear price.</p>
       <div class="cta-actions">
-        <a class="btn btn-primary" href="/contact.html#book">Book PPF consultation</a>
+        <a class="btn btn-primary" href="/contact.html#instant-quote">Get instant quote</a>
         <a class="btn btn-outline" href="/services.html">Compare services</a>
       </div>
     </section>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -68,7 +68,7 @@
       <h2>What data we collect</h2>
       <ul>
         <li><strong>Contact form details:</strong> your name, email, phone, vehicle details, and message.</li>
-        <li><strong>Booking context:</strong> your preferred dates/times and service interests (e.g., coatings, correction, PPF, valeting).</li>
+        <li><strong>Instant quote context:</strong> your preferred dates/times and service interests (e.g., coatings, correction, PPF, valeting).</li>
         <li><strong>Basic site logs:</strong> our hosting may record standard server logs (IP, user-agent, date/time) for security and diagnostics.</li>
       </ul>
     </section>
@@ -82,7 +82,7 @@
       <h2>Why we use your data (lawful bases)</h2>
       <ul>
         <li><strong>To respond to your enquiry and provide quotes</strong> (UK GDPR: <em>legitimate interests</em>).</li>
-        <li><strong>To fulfil a booking / contract</strong> if you proceed (UK GDPR: <em>contract</em>).</li>
+        <li><strong>To fulfil an instant quote / contract</strong> if you proceed (UK GDPR: <em>contract</em>).</li>
         <li><strong>To keep basic records</strong> for tax and accounting (UK GDPR: <em>legal obligation</em>).</li>
       </ul>
     </section>
@@ -136,7 +136,7 @@
 
     <section class="card" style="display:flex; gap:12px; flex-wrap:wrap;">
       <a href="/services.html" class="btn btn-primary">View Services</a>
-      <a href="/contact.html" class="btn btn-outline">Contact / Book</a>
+      <a href="/contact.html#instant-quote" class="btn btn-outline">Get instant quote</a>
     </section>
   </main>
 

--- a/services.html
+++ b/services.html
@@ -197,8 +197,8 @@
     <!-- CTA -->
     <section class="card" style="margin-top:22px;">
       <h2>Not sure what you need?</h2>
-      <p class="muted">Book a free inspection. We’ll assess paint condition, explain options and provide a clear, no-obligation quote.</p>
-      <a href="/contact.html#book" class="btn btn-primary">Book an assessment</a>
+      <p class="muted">Get an instant quote with a free inspection. We’ll assess paint condition, explain options and provide a clear, no-obligation price.</p>
+      <a href="/contact.html#instant-quote" class="btn btn-primary">Get instant quote</a>
     </section>
 
   </main>

--- a/tips.html
+++ b/tips.html
@@ -146,7 +146,7 @@
       <h2 class="cta-title">Want tailored advice for your car?</h2>
       <p class="muted">Send your reg and how you use the vehicle. We’ll recommend the right care routine and products.</p>
       <div class="cta-actions">
-        <a class="btn btn-primary" href="/contact.html#book">Ask a question</a>
+        <a class="btn btn-primary" href="/contact.html#instant-quote">Ask a question</a>
         <a class="btn btn-outline" href="/services.html">Explore services</a>
       </div>
     </section>

--- a/valeting.html
+++ b/valeting.html
@@ -77,7 +77,7 @@
           </ul>
           <p class="muted"><strong>Time:</strong> 1–2 hours (size/condition dependent)</p>
           <div style="margin-top:10px;">
-            <a href="/contact.html#book" class="btn btn-primary">Book Mini Valet</a>
+            <a href="/contact.html#instant-quote" class="btn btn-primary">Get instant quote</a>
           </div>
         </article>
 
@@ -92,7 +92,7 @@
           </ul>
           <p class="muted"><strong>Time:</strong> 2–4 hours</p>
           <div style="margin-top:10px;">
-            <a href="/contact.html#book" class="btn btn-primary">Book Full Valet</a>
+            <a href="/contact.html#instant-quote" class="btn btn-primary">Get instant quote</a>
           </div>
         </article>
 
@@ -107,7 +107,7 @@
           </ul>
           <p class="muted"><strong>Time:</strong> 3–5 hours · <strong>From £80</strong></p>
           <div style="margin-top:10px;">
-            <a href="/contact.html#book" class="btn btn-primary">Book Deep Clean</a>
+            <a href="/contact.html#instant-quote" class="btn btn-primary">Get instant quote</a>
           </div>
         </article>
       </div>
@@ -140,7 +140,7 @@
       </article>
       <article class="card">
         <h3>Perfect alongside coatings</h3>
-        <p class="muted">Many customers book an interior deep clean when choosing ceramic coatings or correction work.</p>
+        <p class="muted">Many customers get an instant quote for an interior deep clean when choosing ceramic coatings or correction work.</p>
       </article>
       <article class="card">
         <h3>Local &amp; straightforward</h3>
@@ -153,7 +153,7 @@
       <h2 class="cta-title">Ready to freshen up your interior?</h2>
       <p class="muted">Tell us your reg and a couple of photos — we’ll recommend the right valet level with a clear price.</p>
       <div class="cta-actions">
-        <a class="btn btn-primary" href="/contact.html#book">Book a valet</a>
+        <a class="btn btn-primary" href="/contact.html#instant-quote">Get instant valet quote</a>
         <a class="btn btn-outline" href="/services.html">Compare services</a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace customer-facing “Book” calls-to-action with “Get instant quote” wording across site content
- update the contact page metadata and instant quote form attribute to align with the new messaging
- rename the booking JavaScript to `instant-quote.js` and update references accordingly

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d86c70046883339fa663ce3034d503