### PR TITLE
Lighten instant quote form styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -99,9 +99,9 @@ a { color:inherit; text-decoration:none; }
   margin-top:18px;
   padding:34px;
   border-radius:var(--radius);
-  background:radial-gradient(circle at top right, rgba(37,99,235,0.35), transparent 55%),
-             radial-gradient(circle at bottom left, rgba(250,204,21,0.18), transparent 60%),
-             linear-gradient(180deg, var(--panel) 0%, #091326 100%);
+  background:radial-gradient(circle at top right, rgba(37,99,235,0.28), transparent 55%),
+             radial-gradient(circle at bottom left, rgba(250,204,21,0.12), transparent 60%),
+             linear-gradient(180deg, #1d2a45 0%, #101c34 100%);
   display:grid;
   grid-template-columns:minmax(0,1fr) minmax(0,1.05fr);
   gap:32px;
@@ -112,7 +112,7 @@ a { color:inherit; text-decoration:none; }
   content:"";
   position:absolute;
   inset:0;
-  background:radial-gradient(circle at 20% 20%, rgba(250,204,21,0.12), transparent 45%);
+  background:radial-gradient(circle at 20% 20%, rgba(250,204,21,0.18), transparent 48%);
   pointer-events:none;
 }
 .instant-quote-hero__copy {
@@ -149,11 +149,11 @@ a { color:inherit; text-decoration:none; }
   display:flex;
   gap:12px;
   align-items:flex-start;
-  background:rgba(12,19,35,0.85);
-  border:1px solid rgba(250,204,21,0.22);
+  background:rgba(25,36,60,0.85);
+  border:1px solid rgba(250,204,21,0.16);
   border-radius:14px;
   padding:12px 14px;
-  box-shadow:0 14px 32px rgba(0,0,0,0.35);
+  box-shadow:0 12px 28px rgba(0,0,0,0.28);
 }
 .instant-quote-points span {
   font-size:1.4rem;
@@ -166,11 +166,11 @@ a { color:inherit; text-decoration:none; }
 }
 .instant-quote-hours,
 .instant-quote-meta-card {
-  background:rgba(10,17,30,0.85);
-  border:1px solid rgba(250,204,21,0.2);
+  background:rgba(22,32,54,0.9);
+  border:1px solid rgba(250,204,21,0.15);
   border-radius:14px;
   padding:16px;
-  box-shadow:0 12px 26px rgba(0,0,0,0.35);
+  box-shadow:0 12px 26px rgba(0,0,0,0.26);
 }
 .instant-quote-hours {
   display:flex;
@@ -183,18 +183,18 @@ a { color:inherit; text-decoration:none; }
 .instant-quote-card {
   position:relative;
   z-index:1;
-  background:rgba(8,15,28,0.92);
-  border:1px solid rgba(250,204,21,0.28);
+  background:rgba(20,30,50,0.92);
+  border:1px solid rgba(250,204,21,0.2);
   border-radius:20px;
   padding:26px;
-  box-shadow:0 22px 42px rgba(0,0,0,0.55);
+  box-shadow:0 20px 38px rgba(0,0,0,0.38);
 }
 .instant-quote-card::before {
   content:"";
   position:absolute;
   inset:0;
   border-radius:inherit;
-  background:linear-gradient(130deg, rgba(250,204,21,0.06), transparent 55%);
+  background:linear-gradient(130deg, rgba(250,204,21,0.12), transparent 55%);
   pointer-events:none;
 }
 .instant-quote-form {
@@ -213,9 +213,9 @@ a { color:inherit; text-decoration:none; }
   width:100%;
   padding:11px 12px;
   border-radius:10px;
-  border:1px solid #2a3346;
-  background:#0f182b;
-  color:#e5e7eb;
+  border:1px solid #314062;
+  background:#1c2844;
+  color:#f1f5f9;
   font-size:0.95rem;
 }
 .instant-quote-form select:disabled {


### PR DESCRIPTION
## Summary
- lighten the instant quote hero gradient and highlight overlays so the section feels brighter
- soften supporting list, card, and meta backgrounds with lighter colors and reduced shadows
- update form field fill and border colours to improve readability against the lighter palette

## Testing
- Manual verification of the contact instant quote section

------
https://chatgpt.com/codex/tasks/task_e_68d900b87ea48333b0e3eba8f80cd65b