### PR TITLE
Add datetime picker to instant quote form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -173,8 +173,13 @@
             </div>
 
             <div class="instant-quote-form__field">
-              <label for="dates">Preferred dates/times</label>
-              <input id="dates" name="dates">
+              <label for="dates">Preferred date &amp; time</label>
+              <input id="dates"
+                     name="dates"
+                     type="datetime-local"
+                     step="900"
+                     data-preferred-slot>
+              <p class="muted instant-quote-hint">Use the calendar to choose when suits you best. We’ll confirm availability when we reply.</p>
             </div>
 
             <div class="instant-quote-form__field instant-quote-form__field--full">

--- a/js/instant-quote.js
+++ b/js/instant-quote.js
@@ -32,6 +32,7 @@
   const hiddenExtras = form.querySelector('#selectedExtrasHidden');
   const hiddenTotal = form.querySelector('#calculatedTotalHidden');
   const hiddenService = form.querySelector('#serviceHidden');
+  const preferredSlotField = form.querySelector('[data-preferred-slot]');
 
   if (
     !makeSelect ||
@@ -585,4 +586,32 @@
     }
     updateTotal();
   });
+
+  const updatePreferredSlotMin = () => {
+    if (!preferredSlotField) {
+      return;
+    }
+    const now = new Date();
+    const stepMinutes = 15;
+    const stepMs = stepMinutes * 60 * 1000;
+    const rounded = new Date(Math.ceil(now.getTime() / stepMs) * stepMs);
+    const toLocalValue = (date) => {
+      const local = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+      return local.toISOString().slice(0, 16);
+    };
+    const minValue = toLocalValue(rounded);
+    preferredSlotField.min = minValue;
+
+    if (preferredSlotField.value) {
+      const provided = new Date(preferredSlotField.value);
+      if (Number.isNaN(provided.getTime()) || provided < rounded) {
+        preferredSlotField.value = '';
+      }
+    }
+  };
+
+  updatePreferredSlotMin();
+  if (preferredSlotField) {
+    preferredSlotField.addEventListener('focus', updatePreferredSlotMin, { once: true });
+  }
 })();


### PR DESCRIPTION
## Summary
- replace the free-text date field with a native date & time picker in the instant quote form
- add client-side logic to prevent past selections and align choices to 15-minute increments

## Testing
- not run (static site, no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d9045e2640833399d80af8b5423dd7