### PR TITLE
Route leisure quote form through FormSubmit

### DIFF
--- a/caravan-motorhome-detailing/index.html
+++ b/caravan-motorhome-detailing/index.html
@@ -330,10 +330,20 @@
         <p class="muted">Dedicated leisure flow with live estimate. Share photos (3–5) so we can confirm the exact scope and availability.</p>
       </header>
       <div class="leisure-form-card">
-        <form class="leisure-form" data-leisure-quote-form enctype="multipart/form-data" novalidate>
+        <form class="leisure-form"
+              action="https://formsubmit.co/b89300d152399ad939e7db161cbb0cfa"
+              method="POST"
+              enctype="multipart/form-data"
+              data-leisure-quote-form
+              novalidate>
           <input type="hidden" name="quote_type" value="leisure">
           <input type="hidden" name="estimate_total_pence" data-estimate-total>
           <input type="hidden" name="estimate_breakdown" data-estimate-breakdown-field>
+          <input type="hidden" name="_next" value="https://polishedandpristine.co.uk/thank-you.html">
+          <input type="hidden" name="_subject" value="Website enquiry: Leisure detailing quote">
+          <input type="hidden" name="_template" value="table">
+          <input type="hidden" name="_captcha" value="false">
+          <input type="text" name="_honey" class="instant-quote-honeypot">
 
           <div class="leisure-form__group">
             <h3>Vehicle &amp; packages</h3>
@@ -479,7 +489,7 @@
             <label class="leisure-field leisure-field--full">
               <span>Upload photos</span>
               <input type="file" name="photos" accept="image/*" multiple>
-              <small class="muted">Add front, rear, one side and roof if accessible. Files auto-compress client-side before sending.</small>
+              <small class="muted">Add front, rear, one side and roof if accessible. Attachments send securely with your quote request.</small>
             </label>
           </div>
 

--- a/js/leisure-quote.js
+++ b/js/leisure-quote.js
@@ -12,7 +12,6 @@
   const scrollBtn = document.querySelector('[data-scroll-to-form]');
   const whatsappSummaryLink = document.querySelector('[data-success-whatsapp]');
   const statusBox = form.querySelector('[data-form-status]');
-  const submitBtn = form.querySelector('[data-submit-btn]');
 
   const vehicleType = form.querySelector('[data-vehicle-type]');
   const lengthBand = form.querySelector('[data-length-band]');
@@ -239,54 +238,24 @@
       });
     }
 
-    form.addEventListener('submit', async (event) => {
-      event.preventDefault();
+    form.addEventListener('submit', (event) => {
       if (!pricingConfig) {
+        event.preventDefault();
+        if (statusBox) {
+          statusBox.textContent = 'Please wait for live pricing to load, then submit again or WhatsApp John on 07468 286651.';
+          statusBox.classList.add('leisure-form__status--error');
+        }
         return;
       }
 
+      if (!currentEstimate) {
+        updateEstimate();
+      }
+
       if (statusBox) {
-        statusBox.textContent = 'Submitting…';
+        statusBox.textContent = 'Submitting securely…';
         statusBox.classList.remove('leisure-form__status--error');
         statusBox.classList.remove('leisure-form__status--success');
-      }
-      if (submitBtn) {
-        submitBtn.disabled = true;
-      }
-
-      const formData = new FormData(form);
-      if (currentEstimate) {
-        formData.set('estimate_total_pence', String(currentEstimate.quote.total_pence));
-        formData.set('estimate_breakdown', JSON.stringify({
-          items: currentEstimate.quote.items,
-          selection: currentEstimate.state,
-        }));
-      }
-
-      try {
-        const response = await fetch('/api/quotes/leisure', {
-          method: 'POST',
-          body: formData,
-        });
-
-        if (!response.ok) {
-          throw new Error('Request failed');
-        }
-
-        const data = await response.json().catch(() => ({}));
-        if (statusBox) {
-          statusBox.textContent = data.message || 'Thanks! We have your leisure quote request. Tap WhatsApp to follow up instantly.';
-          statusBox.classList.add('leisure-form__status--success');
-        }
-      } catch (error) {
-        if (statusBox) {
-          statusBox.textContent = 'Something went wrong sending the quote. Please WhatsApp John on 07468 286651 with your selections.';
-          statusBox.classList.add('leisure-form__status--error');
-        }
-      } finally {
-        if (submitBtn) {
-          submitBtn.disabled = false;
-        }
       }
     });
   };


### PR DESCRIPTION
## Summary
- route the caravan & motorhome quote form through FormSubmit with honeypot and redirect controls
- adjust the leisure quote script to rely on the static submission flow while keeping pricing guardrails
- refresh the attachment helper copy to reflect the new workflow

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68da211e7ae483339b66430465b2ac32