### PR TITLE
Increase card border contrast

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,7 +12,7 @@
   --panel: #0f172a;               /* dark bands */
   --panel-accent: #11264a;
   --card-bg: #ffffff;             /* light cards */
-  --card-border: rgba(15,23,42,0.08);
+  --card-border: rgba(0,0,0,0.35);
   --text: #0f172a;                /* base text on light */
   --muted: #64748b;               /* muted on light */
   --text-inverse: #f8fafc;


### PR DESCRIPTION
## Summary
- darken the shared card border token so white cards and tiles stand out against light backgrounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da2962c4f48333a7775556a7635e1d