### PR TITLE
Clarify ceramic coating and paint correction pages

### DIFF
--- a/ceramic-coatings.html
+++ b/ceramic-coatings.html
@@ -89,11 +89,11 @@
     <!-- Intro -->
     <header class="page-header">
       <h1>Ceramic Coatings — long-life, hydrophobic protection</h1>
-      <p class="muted"><strong>Every ceramic package includes at least a single-stage machine polish</strong> to prepare the paint properly. Multi-stage correction is recommended where defects are heavier.</p>
-      <p class="muted">Our coatings create a tough, glassy layer that bonds to your paintwork. You’ll see faster washing, stronger chemical & UV resistance, and deeper, longer-lasting gloss. Best results when applied after paint correction.</p>
+      <p class="muted"><strong>Every ceramic package includes at least a single-stage machine polish</strong> so the coating bonds to a clean, glossy surface. If your paint has heavier swirling we’ll recommend multi-stage correction first.</p>
+      <p class="muted">Think of ceramic as the protective shell that locks in the finish created by machine polishing. Together they deliver faster washing, stronger chemical &amp; UV resistance, and deeper gloss that holds up to daily use.</p>
       <div style="margin-top:12px;">
         <a class="btn btn-primary" href="/contact.html#instant-quote">Get coating options</a>
-        <a class="btn btn-outline" href="/paint-correction.html" style="margin-left:10px;">Pair with paint correction</a>
+        <a class="btn btn-outline" href="/paint-correction.html" style="margin-left:10px;">See machine polishing process</a>
       </div>
     </header>
 
@@ -133,30 +133,69 @@
     </section>
 
     <!-- Packages -->
-<section class="card" style="margin-top:20px;">
-  <h2>Packages & pricing (polish included)</h2>
-  <div class="grid-3 small-gap" style="margin-top:12px;">
-    <div class="card">
-      <h3>Express — 1 year</h3>
-      <p class="muted">Single-stage machine polish + entry ceramic. Great for newer paint with light defects.</p>
-      <p><strong>From £200</strong> (typical small cars). Time: ~2–3 hours on the day.</p>
-    </div>
-    <div class="card">
-      <h3>Professional — 3 year</h3>
-      <p class="muted">Single or multi-stage polish (as needed) + mid-durability ceramic. Best value for daily drivers.</p>
-      <p><strong>From £450+</strong> depending on size/condition. Time varies by vehicle.</p>
-    </div>
-    <div class="card">
-      <h3>Premium — 5+ year</h3>
-      <p class="muted">Multi-stage polish recommended + long-life ceramic. For enthusiast or high-value cars.</p>
-      <p><strong>Quoted on inspection</strong> — based on paint condition and goals.</p>
-    </div>
-  </div>
-  <div style="margin-top:12px;">
-    <a href="/contact.html#instant-quote" class="btn btn-primary">Request a coating quote</a>
-    <a href="/paint-correction.html" class="btn btn-outline" style="margin-left:10px;">See paint correction detail</a>
-  </div>
-</section>
+    <section class="card" style="margin-top:20px;">
+      <h2>Packages &amp; pricing (polish included)</h2>
+      <div class="grid-3 small-gap" style="margin-top:12px;">
+        <div class="card">
+          <h3>Express — 1 year</h3>
+          <p class="muted">Ideal if your vehicle is new or freshly corrected. Includes deep cleanse, single-stage machine polish and a one-year ceramic layer.</p>
+          <ul class="muted" style="padding-left:18px; line-height:1.6;">
+            <li>One coat on paintwork + trim topper</li>
+            <li>Safe wash &amp; chemical decontamination included</li>
+            <li>Perfect for leases and daily drivers needing easier upkeep</li>
+          </ul>
+          <p><strong>From £200</strong> (typical small cars). Time on site: ~2–3 hours.</p>
+        </div>
+        <div class="card">
+          <h3>Professional — 3 year</h3>
+          <p class="muted">Our most popular package. We refine paint with the stages required, then lay down a three-year coating with enhanced chemical resistance.</p>
+          <ul class="muted" style="padding-left:18px; line-height:1.6;">
+            <li>Two coats on paintwork + wheel face protection</li>
+            <li>Spot wet-sanding and focused correction where needed</li>
+            <li>Includes aftercare kit and maintenance plan</li>
+          </ul>
+          <p><strong>From £450+</strong> depending on vehicle size and condition.</p>
+        </div>
+        <div class="card">
+          <h3>Premium — 5+ year</h3>
+          <p class="muted">For cherished, high-value or ceramic-first vehicles. Multi-stage correction to a near-perfect finish and our longest-lasting coating system.</p>
+          <ul class="muted" style="padding-left:18px; line-height:1.6;">
+            <li>Base + top coat layering for extreme durability</li>
+            <li>Wheels-off ceramic and glass coating available</li>
+            <li>Annual inspection &amp; complimentary topper</li>
+          </ul>
+          <p><strong>Quoted on inspection</strong> — we tailor the schedule to your goals.</p>
+        </div>
+      </div>
+      <div style="margin-top:12px;">
+        <a href="/contact.html#instant-quote" class="btn btn-primary">Request a coating quote</a>
+        <a href="/paint-correction.html" class="btn btn-outline" style="margin-left:10px;">See paint correction detail</a>
+      </div>
+    </section>
+
+    <section class="card" style="margin-top:20px;">
+      <h2>Which package fits your vehicle?</h2>
+      <div class="grid-3 small-gap" style="margin-top:12px;">
+        <div class="card">
+          <h3>Daily driver</h3>
+          <p class="muted">Want hassle-free washing and solid protection? Express keeps things slick without a big time investment.</p>
+        </div>
+        <div class="card">
+          <h3>Long-term ownership</h3>
+          <p class="muted">If you plan to keep the car 3–5 years, the Professional package balances correction time, durability and budget.</p>
+        </div>
+        <div class="card">
+          <h3>Enthusiast / show car</h3>
+          <p class="muted">Premium delivers the “wet look” finish plus the yearly check-ins to keep it that way. Perfect after an in-depth correction.</p>
+        </div>
+      </div>
+      <p class="muted" style="margin-top:8px;">Not sure where you sit? <a href="/contact.html#instant-quote">Share your vehicle and goals</a> and we’ll suggest the best fit.</p>
+    </section>
+
+    <section class="card" style="margin-top:20px;">
+      <h2>Ceramic coatings &amp; machine polishing — how they work together</h2>
+      <p class="muted">Machine polishing (paint correction) chases out the swirls and haze that dull the finish. The ceramic coating then seals in that clarity, adds UV and chemical resistance, and makes future washes safer. If you’re unsure how much polishing you need, read our <a href="/paint-correction.html">machine polishing guide</a> or book a lighting inspection.</p>
+    </section>
 
 
     <!-- Prep & Application -->

--- a/paint-correction.html
+++ b/paint-correction.html
@@ -94,11 +94,12 @@
     <!-- Page intro -->
     <header class="page-header">
       <h1>Paint Correction — remove swirls, restore deep gloss</h1>
-      <p class="muted">We safely reduce defects like swirl marks, light scratches and oxidation with multi-stage machine polishing. Based in Darlington — serving nearby towns within ~25 miles.</p>
+      <p class="muted">Machine polishing is the foundation for every great ceramic coating. We safely reduce swirl marks, light scratches and oxidation so your paint looks freshly finished before protection goes on.</p>
       <div style="margin-top:12px;">
         <a class="btn btn-primary" href="/contact.html#instant-quote">Get instant quote</a>
-        <a class="btn btn-outline" href="#pricing" style="margin-left:10px;">See pricing guide</a>
+        <a class="btn btn-outline" href="/ceramic-coatings.html" style="margin-left:10px;">Compare ceramic packages</a>
       </div>
+      <p class="muted" style="margin-top:12px;">Based in Darlington — serving nearby towns within ~25 miles. Book a free assessment to see what level of correction your vehicle needs.</p>
     </header>
 
     <!-- Before / After preview -->
@@ -120,7 +121,7 @@
     <!-- What is paint correction -->
     <section class="card" style="margin-top:20px;">
       <h2>What is paint correction?</h2>
-      <p class="muted">Paint correction levels the clear coat microscopically to remove or reduce surface defects. We work with measured, safe techniques — not aggressive “cut & buff”. The result is a truer, deeper gloss that lasts longer when protected.</p>
+      <p class="muted">Paint correction levels the clear coat microscopically to remove or reduce surface defects. We measure paint depth, work panel by panel and finish with refinement so you’re left with real clarity — not fillers that wash away.</p>
       <div class="grid-3 small-gap" style="margin-top:12px;">
         <div class="card">
           <h3>Common defects</h3>
@@ -171,23 +172,48 @@
         <div class="card">
           <h3>Single-stage Correction</h3>
           <p class="muted">Ideal for newer paint with light swirling. One polishing stage to lift gloss and reduce minor defects.</p>
+          <ul class="muted" style="padding-left:18px; line-height:1.6;">
+            <li>Includes deep cleanse and iron / tar removal</li>
+            <li>Finishing polish for improved clarity</li>
+            <li>Perfect pre-lease return tidy-up</li>
+          </ul>
           <p><strong>From £150</strong> (small cars). Time: ~2–4 hours.</p>
         </div>
         <div class="card">
           <h3>Multi-stage Correction</h3>
           <p class="muted">Cut + refine to tackle heavier swirls and oxidation. Best balance of defect removal vs. paint safety.</p>
+          <ul class="muted" style="padding-left:18px; line-height:1.6;">
+            <li>Multiple pad &amp; polish combinations tested per panel</li>
+            <li>Spot wet-sanding for deeper defects where safe</li>
+            <li>Finished with protective sealant or ceramic topper</li>
+          </ul>
           <p><strong>From £300+</strong> depending on size/condition. Time: ~4–8+ hours.</p>
         </div>
         <div class="card">
           <h3>Correction + Ceramic</h3>
           <p class="muted">Correction paired with our long-life coating (1–5+ year options) for durable gloss and easier washing.</p>
-          <p><strong>From £450+</strong> depending on coating & vehicle size.</p>
+          <ul class="muted" style="padding-left:18px; line-height:1.6;">
+            <li>Choose 1, 3 or 5+ year ceramic protection</li>
+            <li>Includes coating of paint, trims and wheel faces</li>
+            <li>Aftercare kit &amp; maintenance advice provided</li>
+          </ul>
+          <p><strong>From £450+</strong> depending on coating &amp; vehicle size.</p>
         </div>
       </div>
       <div style="margin-top:12px;">
-      <a href="/contact.html#instant-quote" class="btn btn-primary">Get instant paint correction quote</a>
+        <a href="/contact.html#instant-quote" class="btn btn-primary">Get instant paint correction quote</a>
         <a href="/ceramic-coatings.html" class="btn btn-outline" style="margin-left:10px;">See ceramic coating options</a>
       </div>
+    </section>
+
+    <section class="card" style="margin-top:20px;">
+      <h2>Do I need a ceramic coating afterwards?</h2>
+      <p class="muted">If you want that freshly polished finish to last, a ceramic coating is the easiest way to lock it in. It adds hydrophobic protection, stops grime sticking and makes your maintenance washes less likely to inflict new swirls.</p>
+      <ul class="muted" style="padding-left:18px; line-height:1.7;">
+        <li><strong>Daily driver?</strong> Opt for our Express or Professional ceramic packages for quick, durable protection.</li>
+        <li><strong>Show or weekend car?</strong> The Premium ceramic package includes layered coatings and yearly check-ins.</li>
+        <li>Explore the full options on our <a href="/ceramic-coatings.html">ceramic coating page</a> — it breaks down what’s included at every level.</li>
+      </ul>
     </section>
 
     <!-- Aftercare -->


### PR DESCRIPTION
## Summary
- Expand ceramic coating intro, package descriptions, and guidance so visitors understand the prep included and which option suits them
- Add clearer messaging on how machine polishing and ceramic coatings link together, with direct cross-links between the two services
- Refresh paint correction hero content and package breakdowns, plus a new section recommending ceramic protection after polishing

## Testing
- python3 -m http.server 8000 (manual review for screenshots)


------
https://chatgpt.com/codex/tasks/task_e_68da2e50f3348333ad0f2236500110e0