### PR TITLE
Remove caravan sticky estimate bar and add InstaCaravan spotlight

### DIFF
--- a/caravan-motorhome-detailing/index.html
+++ b/caravan-motorhome-detailing/index.html
@@ -58,6 +58,11 @@
     <!-- HERO -->
     <section class="leisure-hero section-dark">
       <div class="leisure-hero__copy">
+        <div class="instancaravan-highlight" role="note">
+          <span class="instancaravan-highlight__title">🚀 InstaCaravan is now live</span>
+          <span class="instancaravan-highlight__subtitle">Instant caravan availability — tap “Get a Quote”.</span>
+          <span class="instancaravan-highlight__arrow" aria-hidden="true">⬇️</span>
+        </div>
         <span class="instant-quote-badge">New for leisure owners</span>
         <h1>Caravan &amp; Motorhome Detailing<br><small>(Mobile — Darlington +25 miles)</small></h1>
         <p class="lede">Roof cleans, black-streak removal, steam-sanitised interiors, and gel-coat-safe ceramic protection. Black streaks gone. Roof fresh and sealed. Interiors steam-sanitised for families and pets.</p>
@@ -531,18 +536,6 @@
       </div>
     </div>
   </footer>
-
-  <div class="leisure-estimate-bar" data-estimate-bar hidden>
-    <div class="leisure-estimate-bar__summary">
-      <span class="leisure-estimate-bar__label">Estimate</span>
-      <span class="leisure-estimate-bar__value" data-estimate-display>Loading…</span>
-      <span class="leisure-estimate-bar__meta" data-estimate-meta></span>
-    </div>
-    <div class="leisure-estimate-bar__actions">
-      <button class="btn btn-primary" type="button" data-scroll-to-form>Review &amp; Submit</button>
-      <a class="btn btn-outline" data-success-whatsapp href="https://wa.me/447468286651?text=Hi%20John%2C%20I%27d%20like%20a%20caravan%20or%20motorhome%20detailing%20quote.">WhatsApp summary</a>
-    </div>
-  </div>
 
   <!-- JSON-LD -->
   <script type="application/ld+json">

--- a/css/style.css
+++ b/css/style.css
@@ -565,6 +565,62 @@ a:hover { text-decoration:underline; }
   color: var(--muted-inverse);
 }
 
+.instancaravan-highlight {
+  position: relative;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: radial-gradient(circle at top, rgba(250,204,21,0.22), transparent 60%),
+              linear-gradient(135deg, rgba(15,23,42,0.65) 0%, rgba(29,78,216,0.55) 100%);
+  border: 1px solid rgba(250,204,21,0.45);
+  color: var(--text-inverse);
+  box-shadow: 0 20px 38px rgba(15,23,42,0.35);
+  overflow: hidden;
+  text-align: center;
+}
+
+.instancaravan-highlight::before {
+  content: "";
+  position: absolute;
+  inset: -40% 30% auto -40%;
+  height: 140%;
+  background: linear-gradient(120deg, rgba(250,204,21,0.25) 0%, transparent 55%);
+  transform: rotate(-5deg);
+  pointer-events: none;
+}
+
+.instancaravan-highlight__title {
+  position: relative;
+  font-weight: 800;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.instancaravan-highlight__subtitle {
+  position: relative;
+  display: block;
+  margin-top: 6px;
+  font-size: 0.95rem;
+  color: rgba(226,232,240,0.92);
+}
+
+.instancaravan-highlight__arrow {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  width: 100%;
+  margin-top: 10px;
+  font-size: 2rem;
+  line-height: 1;
+  color: var(--brand-gold);
+  animation: instancaravan-bounce 1.4s ease-in-out infinite;
+}
+
+@keyframes instancaravan-bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(6px); }
+}
+
 .leisure-hero__image {
   border-radius: 14px;
   overflow: hidden;
@@ -944,65 +1000,12 @@ a:hover { text-decoration:underline; }
   color: #86efac;
 }
 
-.leisure-estimate-bar {
-  position: fixed;
-  left: 50%;
-  bottom: 20px;
-  transform: translateX(-50%);
-  background: rgba(255,255,255,0.96);
-  border: 1px solid rgba(15,23,42,0.15);
-  border-radius: 999px;
-  padding: 12px 18px;
-  display: flex;
-  gap: 18px;
-  align-items: center;
-  box-shadow: var(--shadow-soft);
-  backdrop-filter: blur(12px);
-  z-index: 80;
-}
-
-.leisure-estimate-bar__summary {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.leisure-estimate-bar__label {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--brand-gold);
-}
-
-.leisure-estimate-bar__value {
-  font-weight: 700;
-  font-size: 1.05rem;
-}
-
-.leisure-estimate-bar__meta {
-  font-size: 0.85rem;
-  color: var(--muted);
-}
-
-.leisure-estimate-bar__actions {
-  display: flex;
-  gap: 10px;
-}
-
 @media (max-width: 980px) {
   .leisure-hero {
     grid-template-columns: 1fr;
   }
   .leisure-coverage {
     grid-template-columns: 1fr;
-  }
-  .leisure-estimate-bar {
-    flex-direction: column;
-    border-radius: 24px;
-    width: calc(100% - 32px);
-    left: 16px;
-    right: 16px;
-    transform: none;
   }
 }
 
@@ -1012,13 +1015,6 @@ a:hover { text-decoration:underline; }
   }
   .leisure-form__row--three {
     grid-template-columns: 1fr;
-  }
-  .leisure-estimate-bar__actions {
-    width: 100%;
-    flex-direction: column;
-  }
-  .leisure-estimate-bar {
-    align-items: stretch;
   }
 }
 
@@ -1031,6 +1027,18 @@ a:hover { text-decoration:underline; }
   }
   .leisure-hero__copy h1 {
     font-size: 1.8rem;
+  }
+  .instancaravan-highlight {
+    padding: 14px 16px;
+  }
+  .instancaravan-highlight__title {
+    font-size: 0.9rem;
+  }
+  .instancaravan-highlight__subtitle {
+    font-size: 0.85rem;
+  }
+  .instancaravan-highlight__arrow {
+    font-size: 1.6rem;
   }
   .leisure-gallery__item img {
     height: 180px;


### PR DESCRIPTION
## Summary
- remove the floating leisure estimate bar from the caravan & motorhome page and associated styles
- add an InstaCaravan hero spotlight with animated arrow to emphasise the instant quote CTA

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68da472d2ca483338458d8d9ef5db312