### PR TITLE
Remove yellow accent border from service cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -472,7 +472,6 @@ a:hover { text-decoration:underline; }
 .service-card {
   background: var(--card-bg);
   border:1px solid var(--card-border);
-  border-top:4px solid var(--brand-gold);
   transition: transform .15s ease, box-shadow .15s ease;
 }
 .service-card:hover { transform: translateY(-2px); box-shadow:0 18px 34px rgba(15,23,42,0.16); }


### PR DESCRIPTION
## Summary
- remove the yellow top border accent from service cards so they match the other card styles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd7100a88c83338d295362f0cb1c11