### PR TITLE
Revamp PPF service page layout and styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -484,6 +484,13 @@ a:hover { text-decoration:underline; }
 .card a.cta { margin-top:0; display:inline-block; font-weight:600; }
 .card .icon { display:none; }
 
+.card--inverse {
+  background:rgba(15,23,42,0.82);
+  border:1px solid rgba(148,163,184,0.35);
+  color:var(--text-inverse);
+}
+.card--inverse .muted { color:var(--muted-inverse); }
+
 /* Gallery */
 .gallery-preview { margin-top:20px; }
 .gallery-item { border-radius:10px; overflow:hidden; background:#0b1220; box-shadow:0 6px 14px rgba(0,0,0,0.35); }
@@ -530,10 +537,19 @@ a:hover { text-decoration:underline; }
   .mobile-toggle { display:block; }
   .brand-logo { width:48px; height:48px; }
   .hero { padding:22px; }
+  .ppf-hero { grid-template-columns:1fr; padding:26px; }
+  .ppf-hero__panel { order: 2; }
 }
 
 @media (max-width:900px) {
   .cards { grid-template-columns:1fr; }
+}
+
+@media (max-width:640px) {
+  .ppf-hero { padding:22px; }
+  .ppf-hero__actions { flex-direction:column; }
+  .ppf-coverage { grid-template-columns:1fr; }
+  .ppf-feature-grid { grid-template-columns:1fr; }
 }
 
 /* --- Mobile nav open --- */
@@ -717,6 +733,172 @@ a:hover { text-decoration:underline; }
 .leisure-pricing__note {
   margin-top: 14px;
   font-size: 0.9rem;
+}
+
+/* --- PPF page --- */
+.ppf-hero {
+  margin-top: 20px;
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(260px, 0.9fr);
+  gap: 28px;
+  padding: 34px;
+  border-radius: var(--radius);
+  background: radial-gradient(circle at 20% 25%, rgba(96,165,250,0.25), transparent 55%),
+              radial-gradient(circle at 85% 15%, rgba(250,204,21,0.18), transparent 60%),
+              linear-gradient(165deg, #101b34 0%, #0b1528 100%);
+  color: var(--text-inverse);
+  overflow: hidden;
+  box-shadow: 0 26px 54px rgba(15,23,42,0.45);
+}
+
+.ppf-hero__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: relative;
+  z-index: 1;
+}
+
+.ppf-hero__eyebrow {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  color: rgba(226,232,240,0.78);
+}
+
+.ppf-hero__lede { color: var(--muted-inverse); margin: 0; }
+
+.ppf-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.ppf-hero__points {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.ppf-hero__points li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  color: var(--muted-inverse);
+}
+
+.ppf-hero__points span {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.ppf-hero__panel {
+  position: relative;
+  z-index: 1;
+  background: rgba(15,23,42,0.78);
+  border: 1px solid rgba(148,163,184,0.35);
+  border-radius: 16px;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: var(--text-inverse);
+  box-shadow: 0 18px 36px rgba(8,12,24,0.45);
+}
+
+.ppf-hero__panel h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--text-inverse);
+}
+
+.ppf-hero__panel ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted-inverse);
+}
+
+.ppf-note {
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+.ppf-hero__panel .ppf-note { color: var(--muted-inverse); }
+
+.section-dark .ppf-note { color: var(--muted-inverse); }
+
+.ppf-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-top: 14px;
+}
+
+.ppf-feature {
+  background: linear-gradient(160deg, rgba(241,245,249,0.94), #ffffff 100%);
+  border: 1px solid rgba(148,163,184,0.35);
+  border-radius: 16px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--text);
+  transition: transform .15s ease, box-shadow .15s ease;
+  box-shadow: var(--shadow-soft);
+}
+
+.ppf-feature:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 40px rgba(15,23,42,0.18);
+}
+
+.ppf-feature__icon {
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.ppf-coverage {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+  margin-top: 16px;
+}
+
+.ppf-coverage-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ppf-coverage-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.ppf-coverage__cta {
+  margin-top: 18px;
+}
+
+.ppf-process {
+  margin: 14px 0 0;
+  padding-left: 20px;
+  line-height: 1.65;
+  color: var(--muted);
+}
+
+.ppf-process strong { color: var(--text); }
+
+.ppf-process li + li {
+  margin-top: 8px;
 }
 
 .leisure-note {

--- a/ppf.html
+++ b/ppf.html
@@ -55,92 +55,121 @@
   <!-- MAIN -->
   <main class="wrap main-content">
 
-    <!-- Intro (dark band) -->
-    <section class="section-dark" style="margin-top:18px;">
-      <h1>Paint Protection Film (PPF)</h1>
-      <p class="lede">
-        Invisible, self-healing protection for bumpers, bonnets and other high-impact areas. Perfect for new cars,
-        motorway miles and preserving corrected finishes.
-      </p>
+    <!-- Hero -->
+    <section class="ppf-hero">
+      <div class="ppf-hero__copy">
+        <p class="ppf-hero__eyebrow">Paint Protection Film</p>
+        <h1>Invisible, self-healing armour for high-impact zones</h1>
+        <p class="ppf-hero__lede">Our PPF installs defend against stone chips, road rash and daily wear while keeping your paintwork looking OEM fresh. Every vehicle is assessed under lighting so the film layout suits how and where you drive.</p>
+        <div class="ppf-hero__actions">
+          <a class="btn btn-primary" href="/contact.html#instant-quote">Book a PPF consultation</a>
+          <a class="btn btn-outline" href="/services.html">Compare all services</a>
+        </div>
+        <ul class="ppf-hero__points">
+          <li><span>🛡️</span>Stops chips on bumpers, bonnets, sills and other strike points</li>
+          <li><span>♻️</span>Self-healing top coat removes light marring with warmth</li>
+          <li><span>🧼</span>Wrap-friendly installs on freshly corrected, decontaminated paint</li>
+        </ul>
+      </div>
+      <aside class="ppf-hero__panel">
+        <h2>Perfect for</h2>
+        <ul>
+          <li>New or freshly corrected cars you want to preserve</li>
+          <li>High motorway mileage and track-day usage</li>
+          <li>Hard-to-repair finishes like matte or satin paint</li>
+        </ul>
+        <p class="ppf-note">We recommend a quick inspection first. It lets us map vulnerable zones and advise the coverage style that balances protection, budget and film choice.</p>
+      </aside>
     </section>
 
-    <!-- Why PPF / Benefits -->
-    <section class="services-preview" style="margin-top:22px;">
-      <div class="grid-3">
-        <article class="service-card">
-          <h2>🛡️ Real protection</h2>
-          <p class="muted">High-impact resistance against stone chips, road rash and abrasion where it matters most.</p>
+    <!-- Benefits -->
+    <section class="card" style="margin-top:26px;">
+      <h2>Why choose professional PPF installs?</h2>
+      <div class="ppf-feature-grid">
+        <article class="ppf-feature">
+          <span class="ppf-feature__icon">✨</span>
+          <h3>OEM-level finish</h3>
+          <p class="muted">Pattern adjustments and wrapped edges keep the film discreet. We work on surgically clean paint so seams stay tight and contamination-free.</p>
         </article>
-        <article class="service-card">
-          <h2>♻️ Self-healing topcoat</h2>
-          <p class="muted">Many films heal light swirls and marring with warmth — keeping the finish looking fresh.</p>
+        <article class="ppf-feature">
+          <span class="ppf-feature__icon">🌦️</span>
+          <h3>Weather &amp; wash friendly</h3>
+          <p class="muted">Modern films resist UV yellowing and stay slick for easy cleaning. Top coats can be layered to boost hydrophobics even further.</p>
         </article>
-        <article class="service-card">
-          <h2>✨ OEM-clean installs</h2>
-          <p class="muted">Tidy edges, wrapped where possible to hide seams. Installed to best practice on clean paint.</p>
+        <article class="ppf-feature">
+          <span class="ppf-feature__icon">🔧</span>
+          <h3>Tailored coverage</h3>
+          <p class="muted">From high-impact kits to full-body wraps, we design coverage around your usage so you only pay for the areas that need protection.</p>
         </article>
       </div>
     </section>
 
     <!-- Coverage options -->
-    <section class="cards small-gap" style="margin-top:22px;">
-      <article class="card">
-        <h3>High-impact packs</h3>
-        <p class="muted">Front bumper, partial bonnet &amp; wings, mirrors, sills — targeted coverage where chips hit first.</p>
-      </article>
-      <article class="card">
-        <h3>Full panel / full car</h3>
-        <p class="muted">Full bonnet/wing kits or complete vehicle wraps for maximum peace of mind and uniform finish.</p>
-      </article>
-      <article class="card">
-        <h3>Finishes &amp; combos</h3>
-        <p class="muted">Gloss, satin/stealth and matte options. Combine with ceramic coating for easier washing.</p>
-      </article>
-    </section>
-
-    <!-- Pricing & instant quote -->
-    <section class="services-preview" style="margin-top:22px;">
-      <div class="grid-3">
-        <article class="service-card">
-          <h2>Assessment first</h2>
-          <p class="muted">We inspect paint condition, panel shapes and edges, then advise the most effective coverage.</p>
+    <section class="card" style="margin-top:24px;">
+      <h2>Popular coverage layouts</h2>
+      <div class="ppf-coverage">
+        <article class="ppf-coverage-card">
+          <h3>High-impact pack</h3>
+          <p class="muted">Front bumper, partial bonnet &amp; wings, mirrors, headlights and sills. Ideal for daily drivers facing heavy motorway debris.</p>
+          <p class="ppf-note">Quoted on inspection — typically from £600+ depending on film choice and vehicle size.</p>
         </article>
-        <article class="service-card">
-          <h2>Typical pricing</h2>
-          <p class="muted"><strong>Quoted on inspection</strong> — high-impact packs typically <strong>from £600+</strong> depending on
-            coverage, film and vehicle size.</p>
+        <article class="ppf-coverage-card">
+          <h3>Full front end</h3>
+          <p class="muted">Full bonnet, wings and bumper with wrapped edges where possible. Keeps the most visible panels defect-free for years.</p>
+          <p class="ppf-note">Popular after paint correction or ceramic coatings to lock in that flawless finish.</p>
         </article>
-        <article class="service-card">
-          <h2>Get instant PPF consult quote</h2>
-          <p class="muted">Tell us your reg and priorities (chips, track use, motorway miles). We’ll outline options &amp; timescales.</p>
-          <a href="/contact.html#instant-quote" class="btn btn-primary" style="margin-top:8px;">Get instant quote</a>
+        <article class="ppf-coverage-card">
+          <h3>Full vehicle wrap</h3>
+          <p class="muted">Complete coverage including door shuts, A-pillars and luggage areas. Available in gloss, satin/stealth or matte conversions.</p>
+          <p class="ppf-note">Perfect for high-value or track cars that demand uniform protection everywhere.</p>
         </article>
+      </div>
+      <div class="ppf-coverage__cta">
+        <a class="btn btn-primary" href="/contact.html#instant-quote">Share your vehicle details</a>
       </div>
     </section>
 
-    <!-- Care & aftercare (dark band) -->
+    <!-- Process -->
+    <section class="card" style="margin-top:24px;">
+      <h2>How our PPF installs run</h2>
+      <ol class="ppf-process">
+        <li><strong>Lighting inspection &amp; plan</strong> — identify chip-prone panels, badge removals and wrap opportunities.</li>
+        <li><strong>Surface preparation</strong> — safe wash, chemical decontamination and panel polishing so film sits flat.</li>
+        <li><strong>Pattern refinement</strong> — tweak templates or bulk-fit panels for tighter wraps and hidden seams.</li>
+        <li><strong>Install &amp; curing</strong> — controlled studio environment ensures clean adhesion and time for edges to settle.</li>
+        <li><strong>Handover</strong> — lighting check, aftercare walk-through and optional ceramic top-up for easier washing.</li>
+      </ol>
+    </section>
+
+    <!-- Pairing info -->
+    <section class="card" style="margin-top:24px;">
+      <h2>Combine with paint correction &amp; ceramic coatings</h2>
+      <p class="muted">If your vehicle has swirl marks or dull panels, we recommend correcting them before film goes down. We can also ceramic coat the exposed panels or the film itself for faster washing and consistent gloss. <a href="/paint-correction.html">See our correction process</a> or explore <a href="/ceramic-coatings.html">ceramic coating packages</a>.</p>
+    </section>
+
+    <!-- Care & aftercare -->
     <section class="section-dark" style="margin-top:30px;">
       <h2>Care &amp; aftercare</h2>
-      <div class="cards small-gap" style="margin-top:10px;">
-        <article class="card">
+      <div class="cards small-gap" style="margin-top:12px;">
+        <article class="card card--inverse">
           <h3>Wash method</h3>
-          <p class="muted">pH-neutral shampoo, soft mitts, gentle drying. Avoid harsh solvents and aggressive APCs.</p>
+          <p class="muted">Use pH-neutral shampoo, soft mitts and gentle drying towels. Avoid aggressive solvents or abrasive polishes.</p>
         </article>
-        <article class="card">
+        <article class="card card--inverse">
           <h3>Edges &amp; seams</h3>
-          <p class="muted">We wrap edges where practical. Where seams are required, they’re placed to be discreet.</p>
+          <p class="muted">We wrap edges wherever practical. If seams are required, they’re positioned to be discreet and easy to keep clean.</p>
         </article>
-        <article class="card">
+        <article class="card card--inverse">
           <h3>Enhancements</h3>
-          <p class="muted">Ceramic top coats can be added to PPF to boost hydrophobics and simplify maintenance.</p>
+          <p class="muted">Ceramic toppers, wheel face protection and glass coatings can be added so the entire vehicle is easier to maintain.</p>
         </article>
       </div>
     </section>
 
-    <!-- CTA (dark band) -->
+    <!-- CTA -->
     <section class="cta-band section-dark" style="margin-top:30px;">
       <h2 class="cta-title">Ready to protect your paint?</h2>
-      <p class="muted">Get an instant quote with a no-obligation inspection. We’ll map the vulnerable zones and give a clear price.</p>
+      <p class="muted">Share your registration, mileage and how you use the vehicle. We’ll map the vulnerable zones and provide a clear quote with coverage options.</p>
       <div class="cta-actions">
         <a class="btn btn-primary" href="/contact.html#instant-quote">Get instant quote</a>
         <a class="btn btn-outline" href="/services.html">Compare services</a>


### PR DESCRIPTION
## Summary
- redesign the PPF landing page with a new hero, coverage breakdown, process overview and refreshed copy
- add page-specific styling, responsive tweaks and inverse card treatment for dark sections
- ensure call-to-action and aftercare guidance align with the updated visual direction

## Testing
- Manually viewed `ppf.html` in the browser


------
https://chatgpt.com/codex/tasks/task_e_68de4c4c94288333b80249bc8d49fe62