### PR TITLE
Fix responsive layout for PPF page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -537,20 +537,13 @@ a:hover { text-decoration:underline; }
   .mobile-toggle { display:block; }
   .brand-logo { width:48px; height:48px; }
   .hero { padding:22px; }
-  .ppf-hero { grid-template-columns:1fr; padding:26px; }
-  .ppf-hero__panel { order: 2; }
 }
 
 @media (max-width:900px) {
   .cards { grid-template-columns:1fr; }
 }
 
-@media (max-width:640px) {
-  .ppf-hero { padding:22px; }
-  .ppf-hero__actions { flex-direction:column; }
-  .ppf-coverage { grid-template-columns:1fr; }
-  .ppf-feature-grid { grid-template-columns:1fr; }
-}
+
 
 /* --- Mobile nav open --- */
 .main-nav.nav-open {
@@ -758,6 +751,7 @@ a:hover { text-decoration:underline; }
   gap: 18px;
   position: relative;
   z-index: 1;
+  min-width: 0;
 }
 
 .ppf-hero__eyebrow {
@@ -808,6 +802,7 @@ a:hover { text-decoration:underline; }
   gap: 14px;
   color: var(--text-inverse);
   box-shadow: 0 18px 36px rgba(8,12,24,0.45);
+  min-width: 0;
 }
 
 .ppf-hero__panel h2 {
@@ -899,6 +894,41 @@ a:hover { text-decoration:underline; }
 
 .ppf-process li + li {
   margin-top: 8px;
+}
+
+@media (max-width: 980px) {
+  .ppf-hero {
+    grid-template-columns: 1fr;
+    padding: 28px;
+  }
+
+  .ppf-hero__panel {
+    order: 2;
+  }
+}
+
+@media (max-width: 720px) {
+  .ppf-hero {
+    padding: 26px;
+  }
+}
+
+@media (max-width: 640px) {
+  .ppf-hero {
+    padding: 24px;
+  }
+
+  .ppf-hero__actions {
+    flex-direction: column;
+  }
+
+  .ppf-coverage {
+    grid-template-columns: 1fr;
+  }
+
+  .ppf-feature-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .leisure-note {


### PR DESCRIPTION
## Summary
- ensure the PPF hero copy and panel respect responsive stacking by adding min-width safeguards
- move the PPF-specific breakpoints after the page styles so the hero, actions and cards stack correctly on small screens

## Testing
- visual check on desktop viewport
- visual check on mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68de51ab7d508333aeec451d53f339d4