### PR TITLE
Add trust assurance chips to home hero

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -76,7 +76,7 @@ a:hover { text-decoration:underline; }
 .hero-copy h1 { font-size:2.25rem; margin:0 0 12px; line-height:1.06; letter-spacing:-0.02em; color:var(--brand-gold); }
 .hero .lede { color:var(--muted-inverse); }
 .lede { color:var(--muted); margin-bottom:16px; font-size:1rem; }
-.hero-ctas { display:flex; gap:12px; margin-bottom:16px; }
+.hero-ctas { display:flex; gap:12px; margin:20px 0 16px; }
 .btn {
   display:inline-block; border-radius:10px; padding:10px 16px; font-weight:800;
   transition:transform .12s ease, box-shadow .12s ease, background .12s ease, color .12s ease;
@@ -92,6 +92,42 @@ a:hover { text-decoration:underline; }
 .features{
   display:grid; grid-template-columns: repeat(2, minmax(0,1fr));
   gap:8px 16px; color:#d5dae3; list-style:none; padding-left:0;
+}
+
+/* trust chips */
+.chips{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  list-style:none;
+  padding:0;
+  margin:18px 0 0;
+}
+.chips li{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 14px;
+  border-radius:999px;
+  background:rgba(15,23,42,0.6);
+  border:1px solid rgba(148,163,184,0.35);
+  color:var(--text-inverse);
+  font-weight:600;
+  font-size:0.95rem;
+  line-height:1.25;
+}
+.chips .i{
+  width:18px;
+  height:18px;
+  color:var(--brand-gold);
+  flex-shrink:0;
+}
+
+@media (max-width: 540px) {
+  .chips li {
+    font-size:0.88rem;
+    padding:7px 12px;
+  }
 }
 
 /* hero image */

--- a/index.html
+++ b/index.html
@@ -46,6 +46,29 @@
 </head>
 <body class="site-body">
 
+  <svg aria-hidden="true" focusable="false" style="position:absolute;width:0;height:0;overflow:hidden;">
+    <defs>
+      <symbol id="i-shield" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M12 2l8 3v6c0 5.47-3.82 10.34-8 11.99C7.82 21.34 4 16.47 4 11V5l8-3z"/>
+      </symbol>
+      <symbol id="i-map-pin" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M12 2a7 7 0 0 0-7 7c0 5.44 7 13 7 13s7-7.56 7-13a7 7 0 0 0-7-7zm0 10a3 3 0 1 1 0-6 3 3 0 0 1 0 6z"/>
+      </symbol>
+      <symbol id="i-gauge" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M12 4a9 9 0 0 0-9 9 9 9 0 0 0 2.64 6.36l1.42-1.42A7 7 0 0 1 5 13a7 7 0 1 1 14 0 7 7 0 0 1-2.06 4.95l1.42 1.41A9 9 0 0 0 21 13a9 9 0 0 0-9-9zm0 4a1 1 0 0 0-.88.52l-2.5 4.5a1 1 0 1 0 1.76.96l2.5-4.5A1 1 0 0 0 12 8z"/>
+      </symbol>
+      <symbol id="i-sparkles" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M12 3l1.4 3.6L17 8l-3.6 1.4L12 13l-1.4-3.6L7 8l3.6-1.4L12 3zm6 8l1 2.5L22 14l-3 1 1 3-3-1-1 3-1-3-3 1 1-3-3-1 3-1 1-2.5L18 11zM5 11l.8 2L8 14l-2.2.8L5 17l-.8-2.2L2 14l2.2-1L5 11z"/>
+      </symbol>
+      <symbol id="i-van" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M3 7h11l4 4h3v6h-2a3 3 0 0 1-6 0H9a3 3 0 0 1-6 0H1V9a2 2 0 0 1 2-2zm11 2H3v6h1.17A3 3 0 0 1 8 17h6v-3h4.17L14 11h0zm4 8a1 1 0 1 0 .001 2.001A1 1 0 0 0 18 17zm-10 0a1 1 0 1 0 .001 2.001A1 1 0 0 0 8 17z"/>
+      </symbol>
+      <symbol id="i-card" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm16 4V6H4v2h16zm0 2H4v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-6z"/>
+      </symbol>
+    </defs>
+  </svg>
+
   <!-- HEADER / NAV -->
   <header class="site-header">
     <div class="wrap header-inner">
@@ -86,6 +109,15 @@
           <strong>All ceramic coatings include a single-stage machine polish.</strong>
           Get an instant quote and a clear, no-nonsense assessment.
         </p>
+
+        <ul class="chips" aria-label="Service assurances">
+          <li><svg class="i" aria-hidden="true" focusable="false"><use href="#i-shield"/></svg> Fully insured</li>
+          <li><svg class="i" aria-hidden="true" focusable="false"><use href="#i-map-pin"/></svg> Darlington + 25 miles</li>
+          <li><svg class="i" aria-hidden="true" focusable="false"><use href="#i-gauge"/></svg> Paint depth readings</li>
+          <li><svg class="i" aria-hidden="true" focusable="false"><use href="#i-sparkles"/></svg> Polish included w/ ceramics</li>
+          <li><svg class="i" aria-hidden="true" focusable="false"><use href="#i-van"/></svg> Mobile service</li>
+          <li><svg class="i" aria-hidden="true" focusable="false"><use href="#i-card"/></svg> Card payments</li>
+        </ul>
 
         <div class="hero-ctas">
           <a href="/contact.html#instant-quote" class="btn btn-primary">Get instant quote</a>


### PR DESCRIPTION
## Summary
- add an inline SVG sprite and trust chip list beneath the home hero copy
- style the new chips for flexible layout and adjust hero CTA spacing

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68de5d6b7d688333a943797939585f59