### PR TITLE
Add footer social links with inline SVG icons

### DIFF
--- a/404.html
+++ b/404.html
@@ -107,6 +107,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/caravan-motorhome-detailing/index.html
+++ b/caravan-motorhome-detailing/index.html
@@ -527,6 +527,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/ceramic-coatings.html
+++ b/ceramic-coatings.html
@@ -266,6 +266,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -327,6 +327,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/css/style.css
+++ b/css/style.css
@@ -1249,3 +1249,19 @@ a:hover { text-decoration:underline; }
     height: 180px;
   }
 }
+
+/* Screenreader-only text (accessibility) */
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+
+/* Social list styling */
+.social-list{display:flex;gap:.6rem;list-style:none;margin:1rem 0;padding:0}
+.social-list li{display:block}
+.social-list a{display:inline-flex;align-items:center;justify-content:center;border:1px solid #e5e7eb;border-radius:10px;padding:.35rem;background:#fff;text-decoration:none}
+.social-list a:hover{border-color:var(--accent, #111)}
+.social-list .i.social{width:22px;height:22px}
+
+/* Optional: dark mode polish */
+@media (prefers-color-scheme: dark){
+  .social-list a{background:#111;border-color:#2a2a2a}
+}
+

--- a/gallery.html
+++ b/gallery.html
@@ -124,6 +124,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -224,6 +224,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/paint-correction.html
+++ b/paint-correction.html
@@ -273,6 +273,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/ppf.html
+++ b/ppf.html
@@ -194,6 +194,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -157,6 +157,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/services.html
+++ b/services.html
@@ -245,6 +245,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/thank-you.html
+++ b/thank-you.html
@@ -102,6 +102,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/tips.html
+++ b/tips.html
@@ -170,6 +170,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>

--- a/valeting.html
+++ b/valeting.html
@@ -176,6 +176,46 @@
           <a href="/tips.html">Expert Advice</a>
           <a href="/privacy-policy.html">Privacy</a>
         </nav>
+        <!-- Footer: Social links only (inline SVG) -->
+        <ul class="social-list" aria-label="Follow Polished & Pristine">
+          <li>
+            <a href="https://www.facebook.com/PolishedandPristine" target="_blank" rel="noopener" aria-label="Facebook">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M13 22v-9h3l1-4h-4V7a2 2 0 0 1 2-2h2V1h-3a5 5 0 0 0-5 5v3H6v4h3v9z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Facebook</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.tiktok.com/@polished_pristine" target="_blank" rel="noopener" aria-label="TikTok">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15 3a5 5 0 0 0 5 5v3a8 8 0 1 1-8 8v-5a3 3 0 1 0 4-3V3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">TikTok</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.instagram.com/polishedpristinemobile/" target="_blank" rel="noopener" aria-label="Instagram">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                <circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/>
+              </svg>
+              <span class="sr-only">Instagram</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://www.yell.com/biz/polished-and-pristine-mobile-darlington-10931334/" target="_blank" rel="noopener" aria-label="Yell profile (reviews)">
+              <svg class="i social" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 3l2.5 5 5.5.8-4 3.9.9 5.6-4.9-2.6-4.9 2.6.9-5.6-4-3.9 5.5-.8L12 3z"
+                      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <span class="sr-only">Yell</span>
+            </a>
+          </li>
+        </ul>
         <div class="small muted">Serving approx. 25-mile radius</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add an inline SVG social links list to each page footer so visitors can reach major platforms
- style the new social list, including a screenreader-only helper class for icon labels and dark-mode polish

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de61e1094c8333873c5ff934837d92