### PR TITLE
Implement Services submenu in main navigation

### DIFF
--- a/404.html
+++ b/404.html
@@ -41,12 +41,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -157,6 +167,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -164,6 +185,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/caravan-motorhome-detailing/index.html
+++ b/caravan-motorhome-detailing/index.html
@@ -39,12 +39,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link nav-active">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link nav-active">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -601,6 +611,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -608,6 +629,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/ceramic-coatings.html
+++ b/ceramic-coatings.html
@@ -70,12 +70,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link nav-active">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link nav-active">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -316,6 +326,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -323,6 +344,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/contact.html
+++ b/contact.html
@@ -37,12 +37,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta nav-active">Contact / Book</a>
@@ -380,6 +390,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -387,6 +408,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/css/style.css
+++ b/css/style.css
@@ -72,6 +72,23 @@ p {
 .main-nav { display:flex; gap:14px; align-items:center; }
 .main-nav a { font-size:0.95rem; padding:6px 8px; border-radius:6px; color:inherit; text-decoration:none; }
 .main-nav a:hover, .nav-link.nav-active { color: var(--brand-gold); }
+.nav-item--has-submenu { position:relative; display:flex; align-items:center; gap:6px; }
+.nav-item-trigger { display:flex; align-items:center; gap:4px; }
+.nav-link--services { display:inline-flex; align-items:center; gap:6px; }
+.nav-submenu-toggle { display:none; background:none; border:0; color:inherit; padding:4px; border-radius:6px; cursor:pointer; line-height:1; transition:color .15s ease, transform .2s ease; }
+.nav-submenu-toggle:hover, .nav-submenu-toggle:focus-visible { color:var(--brand-gold); outline:none; }
+.nav-submenu-toggle-icon { font-size:0.75rem; transition:transform .2s ease; }
+.nav-item--has-submenu.submenu-open .nav-submenu-toggle-icon { transform:rotate(180deg); }
+.nav-submenu { display:none; position:absolute; top:calc(100% + 10px); left:0; background:rgba(15,23,42,0.96); border-radius:12px; border:1px solid rgba(148,163,184,0.25); box-shadow:0 18px 40px rgba(15,23,42,0.4); padding:14px 16px; min-width:220px; flex-direction:column; gap:6px; z-index:70; }
+.nav-submenu .nav-link { white-space:nowrap; display:block; }
+.nav-item--has-submenu.submenu-open .nav-submenu { display:flex; }
+
+@media (min-width:981px) {
+  .nav-item--has-submenu:hover .nav-submenu,
+  .nav-item--has-submenu:focus-within .nav-submenu {
+    display:flex;
+  }
+}
 .nav-cta { background:var(--brand-gold); color:#111827; padding:8px 12px; border-radius:8px; box-shadow:0 12px 28px rgba(250,204,21,0.3); }
 .mobile-toggle { display:none; background:none; border:0; font-size:1.3rem; padding:8px; color:var(--text-inverse); }
 
@@ -584,6 +601,10 @@ p {
   .cards { grid-template-columns:1fr; }
   .grid-3 { grid-template-columns:1fr; }
   .main-nav { display:none; }
+  .nav-item--has-submenu { width:100%; }
+  .nav-item-trigger { width:100%; gap:8px; }
+  .nav-link--services { flex:1; justify-content:flex-start; }
+  .nav-submenu-toggle { display:inline-flex; align-items:center; justify-content:center; font-size:0.85rem; }
   .mobile-toggle { display:block; }
   .brand-logo { width:48px; height:48px; }
   .hero { padding:22px; }
@@ -601,6 +622,48 @@ p {
   background: var(--brand-dark); flex-direction:column; padding:18px;
   box-shadow:0 10px 30px rgba(15,23,42,0.55); z-index:60;
   border-top:1px solid rgba(148,163,184,0.3);
+}
+
+.main-nav.nav-open .nav-item--has-submenu {
+  flex-direction:column;
+  align-items:stretch;
+  gap:6px;
+}
+
+.main-nav.nav-open .nav-item-trigger {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+
+.main-nav.nav-open .nav-submenu-toggle {
+  display:inline-flex;
+}
+
+.main-nav.nav-open .nav-submenu {
+  position:static;
+  background:transparent;
+  border:0;
+  box-shadow:none;
+  padding:0 0 0 12px;
+  margin:0;
+  border-left:2px solid rgba(148,163,184,0.35);
+  display:none;
+  gap:4px;
+}
+
+.main-nav.nav-open .nav-item--has-submenu.submenu-open .nav-submenu {
+  display:flex;
+}
+
+.main-nav.nav-open .nav-submenu .nav-link {
+  padding:6px 4px;
+  border-radius:6px;
+}
+
+.main-nav.nav-open .nav-submenu .nav-link:hover {
+  background:rgba(148,163,184,0.16);
 }
 
 /* --- Leisure (Caravan & Motorhome) page --- */

--- a/gallery.html
+++ b/gallery.html
@@ -39,11 +39,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link nav-active">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -174,6 +185,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -181,6 +203,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/index.html
+++ b/index.html
@@ -84,12 +84,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link nav-active">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -274,6 +284,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -281,6 +302,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/paint-correction.html
+++ b/paint-correction.html
@@ -75,12 +75,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link nav-active">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link nav-active">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -323,6 +333,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -330,6 +351,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/ppf.html
+++ b/ppf.html
@@ -39,12 +39,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link nav-active">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link nav-active">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -244,6 +254,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -251,6 +272,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -40,12 +40,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -207,6 +217,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -214,6 +235,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/services.html
+++ b/services.html
@@ -61,12 +61,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link nav-active">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services nav-active" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -295,6 +305,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -302,6 +323,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/thank-you.html
+++ b/thank-you.html
@@ -40,12 +40,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -152,6 +162,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -159,6 +180,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/tips.html
+++ b/tips.html
@@ -39,12 +39,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link">Valeting</a>
-        <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link nav-active">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -220,6 +230,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -227,6 +248,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();

--- a/valeting.html
+++ b/valeting.html
@@ -39,11 +39,22 @@
 
       <nav class="main-nav" id="mainNav" aria-label="Main navigation">
         <a href="/index.html" class="nav-link">Home</a>
-        <a href="/services.html" class="nav-link">Services</a>
-        <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
-        <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
-        <a href="/ppf.html" class="nav-link">PPF</a>
-        <a href="/valeting.html" class="nav-link nav-active">Valeting</a>
+        <div class="nav-item nav-item--has-submenu">
+          <div class="nav-item-trigger">
+            <a href="/services.html" class="nav-link nav-link--services" aria-haspopup="true" aria-expanded="false" aria-controls="services-submenu">Services</a>
+            <button class="nav-submenu-toggle" type="button" aria-label="Toggle Services submenu" aria-expanded="false" aria-controls="services-submenu">
+              <span class="sr-only">Toggle Services submenu</span>
+              <span aria-hidden="true" class="nav-submenu-toggle-icon">▾</span>
+            </button>
+          </div>
+          <div id="services-submenu" class="nav-submenu" role="group" aria-label="Services">
+            <a href="/paint-correction.html" class="nav-link">Paint Correction</a>
+            <a href="/ceramic-coatings.html" class="nav-link">Ceramic Coatings</a>
+            <a href="/ppf.html" class="nav-link">PPF</a>
+            <a href="/valeting.html" class="nav-link nav-active">Valeting</a>
+            <a href="/caravan-motorhome-detailing" class="nav-link">Caravan &amp; Motorhome</a>
+          </div>
+        </div>
         <a href="/gallery.html" class="nav-link">Gallery</a>
         <a href="/tips.html" class="nav-link">Expert Advice</a>
         <a href="/contact.html" class="nav-cta">Contact / Book</a>
@@ -226,6 +237,17 @@
     (function(){
       const btn = document.getElementById('mobileNavToggle');
       const nav = document.getElementById('mainNav');
+      const submenuItem = nav ? nav.querySelector('.nav-item--has-submenu') : null;
+      const submenuToggle = nav ? nav.querySelector('.nav-submenu-toggle') : null;
+      const servicesLink = nav ? nav.querySelector('.nav-link--services') : null;
+
+      const setSubmenuState = (open) => {
+        if (!submenuItem || !submenuToggle || !servicesLink) return;
+        submenuItem.classList.toggle('submenu-open', open);
+        submenuToggle.setAttribute('aria-expanded', String(open));
+        servicesLink.setAttribute('aria-expanded', String(open));
+      };
+
       if (btn && nav) {
         btn.addEventListener('click', () => {
           const isExpanded = btn.getAttribute('aria-expanded') === 'true';
@@ -233,6 +255,26 @@
           btn.setAttribute('aria-label', isExpanded ? 'Open menu' : 'Close menu');
           btn.textContent = isExpanded ? '☰' : '✕';
           nav.classList.toggle('nav-open');
+          if (isExpanded) {
+            setSubmenuState(false);
+          }
+        });
+      }
+
+      if (submenuToggle) {
+        setSubmenuState(false);
+
+        submenuToggle.addEventListener('click', (event) => {
+          event.preventDefault();
+          const isOpen = submenuToggle.getAttribute('aria-expanded') === 'true';
+          setSubmenuState(!isOpen);
+        });
+
+        document.addEventListener('click', (event) => {
+          if (!nav || nav.contains(event.target)) {
+            return;
+          }
+          setSubmenuState(false);
         });
       }
     })();


### PR DESCRIPTION
## Summary
- wrap the Services-related links in a dropdown container across the static pages so the parent link stays clickable
- add desktop and mobile styling for the new submenu, including hover/focus behaviour and mobile collapse/expand states
- extend the shared inline navigation script to manage submenu aria state, toggle behaviour, and closing logic

## Testing
- Manual verification in desktop and mobile viewport widths

------
https://chatgpt.com/codex/tasks/task_e_68de6c5017c08333b31218daf171e3b7