### PR TITLE
Prevent services submenu from collapsing when moving cursor

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -84,6 +84,14 @@ p {
 .nav-item--has-submenu.submenu-open .nav-submenu { display:flex; }
 
 @media (min-width:981px) {
+  .nav-item--has-submenu::after {
+    content:"";
+    position:absolute;
+    left:0;
+    right:0;
+    top:100%;
+    height:14px;
+  }
   .nav-item--has-submenu:hover .nav-submenu,
   .nav-item--has-submenu:focus-within .nav-submenu {
     display:flex;


### PR DESCRIPTION
## Summary
- add a hover bridge under the Services navigation item so the dropdown stays open while the cursor moves toward the submenu

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de7250d6808333a009525723b64d2d