### PR TITLE
Reduce services dropdown hover gap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -79,7 +79,7 @@ p {
 .nav-submenu-toggle:hover, .nav-submenu-toggle:focus-visible { color:var(--brand-gold); outline:none; }
 .nav-submenu-toggle-icon { font-size:0.75rem; transition:transform .2s ease; }
 .nav-item--has-submenu.submenu-open .nav-submenu-toggle-icon { transform:rotate(180deg); }
-.nav-submenu { display:none; position:absolute; top:calc(100% + 10px); left:0; background:rgba(15,23,42,0.96); border-radius:12px; border:1px solid rgba(148,163,184,0.25); box-shadow:0 18px 40px rgba(15,23,42,0.4); padding:14px 16px; min-width:220px; flex-direction:column; gap:6px; z-index:70; }
+.nav-submenu { display:none; position:absolute; top:calc(100% + 2px); left:0; background:rgba(15,23,42,0.96); border-radius:12px; border:1px solid rgba(148,163,184,0.25); box-shadow:0 18px 40px rgba(15,23,42,0.4); padding:14px 16px; min-width:220px; flex-direction:column; gap:6px; z-index:70; }
 .nav-submenu .nav-link { white-space:nowrap; display:block; }
 .nav-item--has-submenu.submenu-open .nav-submenu { display:flex; }
 
@@ -87,10 +87,10 @@ p {
   .nav-item--has-submenu::after {
     content:"";
     position:absolute;
-    left:0;
-    right:0;
+    left:-12px;
+    right:-12px;
     top:100%;
-    height:14px;
+    height:12px;
   }
   .nav-item--has-submenu:hover .nav-submenu,
   .nav-item--has-submenu:focus-within .nav-submenu {


### PR DESCRIPTION
## Summary
- move the desktop services submenu closer to the navigation trigger
- widen the invisible hover bridge so the submenu stays open when moving the pointer downward

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de9bb1ad0083339792b088e69165cf