### PR TITLE
Refresh site with bright light theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,25 +1,25 @@
-/* Polished & Pristine — central stylesheet (DARK THEME) */
+/* Polished & Pristine — central stylesheet (LIGHT THEME) */
 
 /* --- Theme variables --- */
 :root{
-  --brand-blue: #1d4ed8;
-  --brand-blue-hover: #1a40b0;
-  --brand-blue-light: #60a5fa;
-  --brand-gold: #facc15;
-  --brand-gold-hover: #eab308;
-  --brand-dark: #0f172a;
-  --bg: #f5f7fb;                 /* page background (light) */
-  --panel: #0f172a;               /* dark bands */
-  --panel-accent: #11264a;
+  --brand-blue: #2563eb;
+  --brand-blue-hover: #1d4ed8;
+  --brand-blue-light: #bfdbfe;
+  --brand-gold: #fbbf24;
+  --brand-gold-hover: #f59e0b;
+  --brand-dark: #ffffff;
+  --bg: #f8fbff;                 /* page background */
+  --panel: #ffffff;               /* light bands */
+  --panel-accent: #e4edff;
   --card-bg: #ffffff;             /* light cards */
-  --card-border: rgba(0,0,0,0.35);
+  --card-border: rgba(15,23,42,0.12);
   --text: #0f172a;                /* base text on light */
-  --muted: #64748b;               /* muted on light */
-  --text-inverse: #f8fafc;
-  --muted-inverse: rgba(226,232,240,0.82);
+  --muted: #475569;               /* muted on light */
+  --text-inverse: #ffffff;
+  --muted-inverse: rgba(255,255,255,0.72);
   --radius: 12px;
   --max-width: 1100px;
-  --shadow-soft: 0 18px 38px rgba(15,23,42,0.12);
+  --shadow-soft: 0 18px 38px rgba(15,23,42,0.08);
 }
 
 /* --- Base / resets --- */
@@ -58,20 +58,21 @@ p {
 .site-header{
   background: var(--brand-dark);
   position:sticky; top:0; z-index:50;
-  border-bottom:1px solid rgba(15,23,42,0.6);
-  color:var(--text-inverse);
+  border-bottom:1px solid rgba(15,23,42,0.08);
+  box-shadow:0 10px 30px rgba(15,23,42,0.06);
+  color:var(--text);
 }
 .site-header a { color:inherit; }
 .header-inner { display:flex; align-items:center; justify-content:space-between; gap:20px; }
 .brand { display:flex; align-items:center; gap:12px; color:inherit; }
-.brand-logo { width:56px; height:56px; border-radius:10px; object-fit:cover; background:#0c1220; }
+.brand-logo { width:56px; height:56px; border-radius:10px; object-fit:cover; background:#e1e8ff; box-shadow:0 6px 16px rgba(37,99,235,0.18); }
 .brand-name { font-weight:800; font-size:1.05rem; }
 .brand-tag { color:var(--muted); font-size:0.85rem; }
 
 /* --- Nav --- */
 .main-nav { display:flex; gap:14px; align-items:center; }
-.main-nav a { font-size:0.95rem; padding:6px 8px; border-radius:6px; color:inherit; text-decoration:none; }
-.main-nav a:hover, .nav-link.nav-active { color: var(--brand-gold); }
+.main-nav a { font-size:0.95rem; padding:6px 8px; border-radius:6px; color:inherit; text-decoration:none; transition:background .15s ease, color .15s ease; }
+.main-nav a:hover, .nav-link.nav-active { color: var(--brand-blue-hover); background:rgba(37,99,235,0.08); }
 .nav-item--has-submenu { position:relative; display:flex; align-items:center; gap:6px; }
 .nav-item-trigger { display:flex; align-items:center; gap:4px; }
 .nav-link--services { display:inline-flex; align-items:center; gap:6px; }
@@ -79,7 +80,9 @@ p {
 .nav-submenu-toggle:hover, .nav-submenu-toggle:focus-visible { color:var(--brand-gold); outline:none; }
 .nav-submenu-toggle-icon { font-size:0.75rem; transition:transform .2s ease; }
 .nav-item--has-submenu.submenu-open .nav-submenu-toggle-icon { transform:rotate(180deg); }
-.nav-submenu { display:none; position:absolute; top:calc(100% + 2px); left:0; background:rgba(15,23,42,0.96); border-radius:12px; border:1px solid rgba(148,163,184,0.25); box-shadow:0 18px 40px rgba(15,23,42,0.4); padding:14px 16px; min-width:220px; flex-direction:column; gap:6px; z-index:70; }
+.nav-submenu { display:none; position:absolute; top:calc(100% + 2px); left:0; background:#ffffff; border-radius:12px; border:1px solid rgba(15,23,42,0.12); box-shadow:0 18px 40px rgba(15,23,42,0.1); padding:14px 16px; min-width:220px; flex-direction:column; gap:6px; z-index:70; }
+.nav-submenu .nav-link { color:var(--text); }
+.nav-submenu .nav-link:hover { color:var(--brand-blue-hover); }
 .nav-submenu .nav-link { white-space:nowrap; display:block; }
 .nav-item--has-submenu.submenu-open .nav-submenu { display:flex; }
 
@@ -97,8 +100,9 @@ p {
     display:flex;
   }
 }
-.nav-cta { background:var(--brand-gold); color:#111827; padding:8px 12px; border-radius:8px; box-shadow:0 12px 28px rgba(250,204,21,0.3); }
-.mobile-toggle { display:none; background:none; border:0; font-size:1.3rem; padding:8px; color:var(--text-inverse); }
+.nav-cta { background:var(--brand-blue); color:#ffffff; padding:8px 12px; border-radius:8px; box-shadow:0 12px 28px rgba(37,99,235,0.2); }
+.nav-cta:hover { background:var(--brand-blue-hover); color:#ffffff; }
+.mobile-toggle { display:none; background:none; border:0; font-size:1.3rem; padding:8px; color:var(--text); }
 
 /* --- Hero --- */
 .hero{
@@ -107,13 +111,14 @@ p {
   display:grid; grid-template-columns:minmax(320px,560px) 1fr;
   gap:24px; align-items:stretch; margin-top:18px;
   border-radius: var(--radius);
-  padding:28px;
-  background: radial-gradient(circle at top left, rgba(96,165,250,0.2), transparent 55%),
-              linear-gradient(165deg, var(--panel) 0%, var(--panel-accent) 100%);
-  color:var(--text-inverse);
+  padding:32px;
+  background: radial-gradient(circle at top left, rgba(191,219,254,0.45), transparent 55%),
+              linear-gradient(150deg, #ffffff 0%, #e9f2ff 100%);
+  color:var(--text);
+  box-shadow:0 24px 48px rgba(15,23,42,0.08);
 }
-.hero-copy h1 { font-size:2.25rem; margin:0 0 12px; line-height:1.06; letter-spacing:-0.02em; color:var(--brand-gold); }
-.hero .lede { color:var(--muted-inverse); }
+.hero-copy h1 { font-size:2.4rem; margin:0 0 12px; line-height:1.05; letter-spacing:-0.02em; color:var(--brand-blue); }
+.hero .lede { color:var(--muted); }
 .lede { color:var(--muted); margin-bottom:16px; font-size:1rem; }
 .hero-ctas { display:flex; gap:12px; margin:20px 0 16px; }
 .btn {
@@ -122,15 +127,15 @@ p {
   text-decoration:none;
 }
 .btn:hover { transform: translateY(-1px); box-shadow:0 12px 24px rgba(15,23,42,0.18); }
-.btn-primary { background:var(--brand-gold); color:#1f2937; box-shadow:0 14px 28px rgba(250,204,21,0.35); }
-.btn-primary:hover { background:var(--brand-gold-hover); }
+.btn-primary { background:var(--brand-blue); color:#ffffff; box-shadow:0 14px 28px rgba(37,99,235,0.22); }
+.btn-primary:hover { background:var(--brand-blue-hover); }
 .btn-outline { border:2px solid var(--brand-blue); color:var(--brand-blue); background:transparent; box-shadow:none; }
 .btn-outline:hover { background:rgba(29,78,216,0.08); color:var(--brand-blue-hover); border-color:var(--brand-blue-hover); }
 
 /* features */
 .features{
   display:grid; grid-template-columns: repeat(2, minmax(0,1fr));
-  gap:8px 16px; color:#d5dae3; list-style:none; padding-left:0;
+  gap:8px 16px; color:var(--text); list-style:none; padding-left:0;
 }
 
 /* trust chips */
@@ -148,9 +153,9 @@ p {
   gap:8px;
   padding:8px 14px;
   border-radius:999px;
-  background:rgba(15,23,42,0.6);
-  border:1px solid rgba(148,163,184,0.35);
-  color:var(--text-inverse);
+  background:rgba(191,219,254,0.45);
+  border:1px solid rgba(37,99,235,0.25);
+  color:var(--brand-blue-hover);
   font-weight:600;
   font-size:0.95rem;
   line-height:1.25;
@@ -172,33 +177,33 @@ p {
 /* hero image */
 .hero-image { height:100%; }
 .hero-image img{
-  width:100%; height:100%; object-fit:cover; border-radius:12px;
-  box-shadow:0 10px 30px rgba(0,0,0,0.5);
+  width:100%; height:100%; object-fit:cover; border-radius:16px;
+  box-shadow:0 18px 40px rgba(37,99,235,0.18);
 }
 
 /* --- Dark bands (shared) --- */
 .section-dark{
-  background: linear-gradient(165deg, var(--panel) 0%, var(--panel-accent) 100%);
-  color:var(--text-inverse);
+  background: linear-gradient(160deg, #ffffff 0%, #eef4ff 100%);
+  color:var(--text);
   border-radius: var(--radius);
   padding:32px 28px;
-  box-shadow:0 24px 48px rgba(15,23,42,0.35);
+  box-shadow:0 24px 48px rgba(15,23,42,0.08);
 }
-.section-dark .muted { color:var(--muted-inverse); }
-.section-dark h1, .section-dark h2, .section-dark h3 { color:var(--text-inverse); }
-.section-dark a { color:var(--brand-gold); }
-.section-dark a:hover { color:var(--brand-gold-hover); }
+.section-dark .muted { color:var(--muted); }
+.section-dark h1, .section-dark h2, .section-dark h3 { color:var(--text); }
+.section-dark a { color:var(--brand-blue); }
+.section-dark a:hover { color:var(--brand-blue-hover); }
 .section-dark .btn-primary {
-  color:#1f2937;
+  color:#ffffff;
 }
 .section-dark .btn-outline {
-  border-color:rgba(96,165,250,0.9);
-  color:var(--brand-blue-light);
+  border-color:rgba(37,99,235,0.35);
+  color:var(--brand-blue);
 }
 .section-dark .btn-outline:hover {
-  background:rgba(96,165,250,0.18);
-  color:#dbeafe;
-  border-color:#bfdbfe;
+  background:rgba(37,99,235,0.08);
+  color:var(--brand-blue-hover);
+  border-color:rgba(37,99,235,0.4);
 }
 
 /* Contact instant quote */
@@ -207,14 +212,15 @@ p {
   margin-top:18px;
   padding:34px;
   border-radius:var(--radius);
-  background:radial-gradient(circle at top right, rgba(37,99,235,0.28), transparent 55%),
-             radial-gradient(circle at bottom left, rgba(250,204,21,0.12), transparent 60%),
-             linear-gradient(180deg, #1d2a45 0%, #101c34 100%);
+  background:radial-gradient(circle at top right, rgba(37,99,235,0.18), transparent 55%),
+             radial-gradient(circle at bottom left, rgba(251,191,36,0.16), transparent 60%),
+             linear-gradient(180deg, #ffffff 0%, #edf4ff 100%);
   display:grid;
   grid-template-columns:minmax(0,1fr) minmax(0,1.05fr);
   gap:32px;
   align-items:stretch;
   overflow:hidden;
+  box-shadow:0 24px 48px rgba(15,23,42,0.08);
 }
 .instant-quote-hero::before {
   content:"";
@@ -232,8 +238,8 @@ p {
 }
 .instant-quote-badge {
   align-self:flex-start;
-  background:rgba(250,204,21,0.18);
-  color:var(--brand-gold);
+  background:rgba(37,99,235,0.12);
+  color:var(--brand-blue);
   padding:6px 14px;
   border-radius:999px;
   font-weight:700;
@@ -357,8 +363,8 @@ p {
   display:flex;
   gap:8px;
   align-items:center;
-  background:rgba(29,78,216,0.08);
-  border:1px solid rgba(29,78,216,0.2);
+  background:rgba(37,99,235,0.08);
+  border:1px solid rgba(37,99,235,0.18);
   border-radius:999px;
   padding:6px 12px;
   font-size:0.9rem;
@@ -369,7 +375,7 @@ p {
   text-transform:uppercase;
   letter-spacing:0.12em;
   font-size:0.7rem;
-  color:var(--brand-gold);
+  color:var(--brand-blue-hover);
 }
 .instant-quote-hint {
   font-size:0.9rem;
@@ -524,10 +530,11 @@ p {
 .card {
   display:flex;
   flex-direction:column;
-  background:#fff;
-  border:1px solid #e3e7ef;
+  background:var(--card-bg);
+  border:1px solid var(--card-border);
   border-radius:12px;
   padding:1rem;
+  box-shadow:0 16px 32px rgba(15,23,42,0.05);
 }
 
 .cards { display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:16px; }
@@ -549,7 +556,7 @@ p {
   border:1px solid var(--card-border);
   transition: transform .15s ease, box-shadow .15s ease;
 }
-.service-card:hover { transform: translateY(-2px); box-shadow:0 18px 34px rgba(15,23,42,0.16); }
+.service-card:hover { transform: translateY(-2px); box-shadow:0 18px 34px rgba(37,99,235,0.16); }
 .link-more { display:inline-block; margin-top:10px; color:var(--brand-blue); font-weight:600; }
 .link-more:hover { color:var(--brand-blue-hover); }
 
@@ -560,34 +567,36 @@ p {
 .card .icon { display:none; }
 
 .card--inverse {
-  background:rgba(15,23,42,0.82);
-  border:1px solid rgba(148,163,184,0.35);
-  color:var(--text-inverse);
+  background:linear-gradient(135deg, #2563eb 0%, #60a5fa 100%);
+  border:1px solid rgba(37,99,235,0.35);
+  color:#ffffff;
+  box-shadow:0 20px 40px rgba(37,99,235,0.25);
 }
-.card--inverse .muted { color:var(--muted-inverse); }
+.card--inverse .muted { color:rgba(255,255,255,0.8); }
 
 /* Gallery */
 .gallery-preview { margin-top:20px; }
-.gallery-item { border-radius:10px; overflow:hidden; background:#0b1220; box-shadow:0 6px 14px rgba(0,0,0,0.35); }
+.gallery-item { border-radius:10px; overflow:hidden; background:#ffffff; box-shadow:0 10px 24px rgba(15,23,42,0.12); }
 .gallery-item img { width:100%; height:170px; object-fit:cover; display:block; }
 
 /* CTA band */
-.cta-band { text-align:center; padding:46px 24px; }
-.cta-band .cta-title { margin:0 0 8px; color:#fff; }
+.cta-band { text-align:center; padding:46px 24px; background:linear-gradient(145deg, #ffffff 0%, #e5f0ff 100%); border-radius:var(--radius); box-shadow:0 20px 40px rgba(15,23,42,0.08); }
+.cta-band .cta-title { margin:0 0 8px; color:var(--brand-blue); }
 .cta-band .cta-actions { display:flex; gap:12px; justify-content:center; margin-top:12px; flex-wrap:wrap; }
 
 /* --- Footer --- */
 .site-footer {
   margin-top:40px;
-  background:linear-gradient(180deg, var(--brand-dark) 0%, #0b1220 100%);
+  background:linear-gradient(180deg, #ffffff 0%, #e2e8f0 100%);
   padding:28px 0;
-  color:var(--text-inverse);
+  color:var(--text);
+  border-top:1px solid rgba(15,23,42,0.08);
 }
 .footer-inner { display:flex; justify-content:space-between; gap:20px; align-items:center; }
-.footer-nav a { margin-right:12px; color:var(--muted-inverse); }
-.footer-nav a:hover { color:var(--brand-gold); }
-.site-footer a { color:var(--text-inverse); text-decoration:none; }
-.site-footer a:hover { color:var(--brand-gold); }
+.footer-nav a { margin-right:12px; color:var(--muted); }
+.footer-nav a:hover { color:var(--brand-blue-hover); }
+.site-footer a { color:var(--text); text-decoration:none; }
+.site-footer a:hover { color:var(--brand-blue-hover); }
 
 /* --- Utilities --- */
 .muted { color:var(--muted); font-size:0.95rem; }
@@ -627,9 +636,9 @@ p {
 /* --- Mobile nav open --- */
 .main-nav.nav-open {
   display:flex; position:fixed; left:0; top:72px; right:0;
-  background: var(--brand-dark); flex-direction:column; padding:18px;
-  box-shadow:0 10px 30px rgba(15,23,42,0.55); z-index:60;
-  border-top:1px solid rgba(148,163,184,0.3);
+  background:#ffffff; flex-direction:column; padding:18px;
+  box-shadow:0 18px 36px rgba(15,23,42,0.12); z-index:60;
+  border-top:1px solid rgba(15,23,42,0.08);
 }
 
 .main-nav.nav-open .nav-item--has-submenu {
@@ -656,7 +665,7 @@ p {
   box-shadow:none;
   padding:0 0 0 12px;
   margin:0;
-  border-left:2px solid rgba(148,163,184,0.35);
+  border-left:2px solid rgba(37,99,235,0.18);
   display:none;
   gap:4px;
 }
@@ -671,7 +680,7 @@ p {
 }
 
 .main-nav.nav-open .nav-submenu .nav-link:hover {
-  background:rgba(148,163,184,0.16);
+  background:rgba(37,99,235,0.08);
 }
 
 /* --- Leisure (Caravan & Motorhome) page --- */
@@ -687,14 +696,18 @@ p {
   gap: 28px;
   position: relative;
   overflow: hidden;
+  padding: 30px;
+  border-radius: 20px;
+  background: linear-gradient(150deg, #ffffff 0%, #edf4ff 100%);
+  box-shadow: 0 24px 48px rgba(15,23,42,0.08);
 }
 
 .leisure-hero::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 10% 10%, rgba(250,204,21,0.14), transparent 45%),
-              radial-gradient(circle at 80% 20%, rgba(29,78,216,0.28), transparent 65%);
+  background: radial-gradient(circle at 12% 15%, rgba(191,219,254,0.55), transparent 45%),
+              radial-gradient(circle at 85% 25%, rgba(251,191,36,0.3), transparent 65%);
   pointer-events: none;
 }
 
@@ -712,18 +725,18 @@ p {
   margin: 0;
   line-height: 1.05;
   letter-spacing: -0.02em;
-  color: var(--brand-gold);
+  color: var(--brand-blue);
 }
 
 .leisure-hero__copy small {
   font-size: 1rem;
-  color: var(--muted-inverse);
+  color: var(--muted);
 }
 
 .leisure-hero__image {
   border-radius: 14px;
   overflow: hidden;
-  box-shadow: 0 20px 40px rgba(0,0,0,0.45);
+  box-shadow: 0 18px 42px rgba(37,99,235,0.16);
 }
 
 .leisure-hero__image img {
@@ -858,12 +871,12 @@ p {
   gap: 28px;
   padding: 34px;
   border-radius: var(--radius);
-  background: radial-gradient(circle at 20% 25%, rgba(96,165,250,0.25), transparent 55%),
-              radial-gradient(circle at 85% 15%, rgba(250,204,21,0.18), transparent 60%),
-              linear-gradient(165deg, #101b34 0%, #0b1528 100%);
-  color: var(--text-inverse);
+  background: radial-gradient(circle at 20% 25%, rgba(191,219,254,0.55), transparent 55%),
+              radial-gradient(circle at 85% 15%, rgba(251,191,36,0.25), transparent 60%),
+              linear-gradient(165deg, #ffffff 0%, #edf3ff 100%);
+  color: var(--text);
   overflow: hidden;
-  box-shadow: 0 26px 54px rgba(15,23,42,0.45);
+  box-shadow: 0 26px 54px rgba(15,23,42,0.12);
 }
 
 .ppf-hero__copy {
@@ -880,10 +893,10 @@ p {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-weight: 700;
-  color: rgba(226,232,240,0.78);
+  color: var(--brand-blue);
 }
 
-.ppf-hero__lede { color: var(--muted-inverse); margin: 0; }
+.ppf-hero__lede { color: var(--muted); margin: 0; }
 
 .ppf-hero__actions {
   display: flex;
@@ -903,7 +916,7 @@ p {
   display: flex;
   gap: 12px;
   align-items: flex-start;
-  color: var(--muted-inverse);
+  color: var(--muted);
 }
 
 .ppf-hero__points span {
@@ -914,28 +927,28 @@ p {
 .ppf-hero__panel {
   position: relative;
   z-index: 1;
-  background: rgba(15,23,42,0.78);
-  border: 1px solid rgba(148,163,184,0.35);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 16px;
   padding: 22px;
   display: flex;
   flex-direction: column;
   gap: 14px;
-  color: var(--text-inverse);
-  box-shadow: 0 18px 36px rgba(8,12,24,0.45);
+  color: var(--text);
+  box-shadow: 0 20px 42px rgba(15,23,42,0.12);
   min-width: 0;
 }
 
 .ppf-hero__panel h2 {
   margin: 0;
   font-size: 1.35rem;
-  color: var(--text-inverse);
+  color: var(--text);
 }
 
 .ppf-hero__panel ul {
   margin: 0;
   padding-left: 18px;
-  color: var(--muted-inverse);
+  color: var(--muted);
 }
 
 .ppf-note {
@@ -943,9 +956,9 @@ p {
   color: var(--muted);
 }
 
-.ppf-hero__panel .ppf-note { color: var(--muted-inverse); }
+.ppf-hero__panel .ppf-note { color: var(--muted); }
 
-.section-dark .ppf-note { color: var(--muted-inverse); }
+.section-dark .ppf-note { color: var(--muted); }
 
 .ppf-feature-grid {
   display: grid;
@@ -1066,7 +1079,7 @@ p {
 .leisure-gallery__item {
   border-radius: 16px;
   overflow: hidden;
-  box-shadow: 0 18px 34px rgba(0,0,0,0.35);
+  box-shadow: 0 18px 38px rgba(37,99,235,0.14);
 }
 
 .leisure-gallery__item img {


### PR DESCRIPTION
## Summary
- restyle the global palette with bright light-theme variables, refreshed header, and refined navigation hover states
- redesign hero, feature chips, and highlight sections with airy gradients and softer shadows
- refresh specialist sections like the leisure and PPF heroes plus CTA/footer blocks to match the new light aesthetic

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_b_68e6805baaf8832cb1949b6bd76b0857